### PR TITLE
fix: changed the position for the delete button in edit mode for block listing

### DIFF
--- a/src/theme/_cms-ui.scss
+++ b/src/theme/_cms-ui.scss
@@ -448,6 +448,20 @@ body.cms-ui {
         padding-bottom: 0.2rem !important; //per simulare il pb-4
       }
     }
+    &.full-width {
+      .drag.handle.wrapper {
+        left: 20%;
+        @media (max-width: #{map-get($grid-breakpoints, sm)}) {
+          left: 10%;
+        }
+      }
+      .ui.delete-button {
+        right: 20%;
+        @media (max-width: #{map-get($grid-breakpoints, sm)}) {
+          right: 10%;
+        }
+      }
+    }
   }
 
   .simple-text-editor-widget {


### PR DESCRIPTION
Cambiato bottoni sposta e cancella dei blocchi elenco quando ne hanno la classe full-width
<img width="1338" alt="Schermata 2024-09-20 alle 12 56 18" src="https://github.com/user-attachments/assets/f6b15650-9129-4ec8-8209-fe71c5775c78">
<img width="545" alt="Schermata 2024-09-20 alle 12 56 38" src="https://github.com/user-attachments/assets/4c5076d8-e70e-4354-af61-bc911db9ec92">
