### PR TITLE
Block table - volto-slate - a11y

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -1077,6 +1077,11 @@ msgstr ""
 msgid "appStoreLink"
 msgstr ""
 
+#. Default: "ascending"
+#: overrideTranslations
+msgid "ascendingTableSort"
+msgstr ""
+
 #. Default: "Allegato"
 #: components/Cards/CardFile/CardFile
 msgid "attachment"
@@ -1725,6 +1730,11 @@ msgstr ""
 #. Default: "delete"
 #: components/Blocks/Accordion/EditBlockWrapper
 msgid "delete"
+msgstr ""
+
+#. Default: "descending"
+#: overrideTranslations
+msgid "descendingTableSort"
 msgstr ""
 
 #. Default: "Testo per il link al dettaglio"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -1072,6 +1072,11 @@ msgstr "Opening date"
 msgid "appStoreLink"
 msgstr ""
 
+#. Default: "ascending"
+#: overrideTranslations
+msgid "ascendingTableSort"
+msgstr ""
+
 #. Default: "Allegato"
 #: components/Cards/CardFile/CardFile
 msgid "attachment"
@@ -1720,6 +1725,11 @@ msgstr "Start date"
 #. Default: "delete"
 #: components/Blocks/Accordion/EditBlockWrapper
 msgid "delete"
+msgstr ""
+
+#. Default: "descending"
+#: overrideTranslations
+msgid "descendingTableSort"
 msgstr ""
 
 #. Default: "Testo per il link al dettaglio"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -1079,6 +1079,11 @@ msgstr ""
 msgid "appStoreLink"
 msgstr ""
 
+#. Default: "ascending"
+#: overrideTranslations
+msgid "ascendingTableSort"
+msgstr ""
+
 #. Default: "Allegato"
 #: components/Cards/CardFile/CardFile
 msgid "attachment"
@@ -1727,6 +1732,11 @@ msgstr ""
 #. Default: "delete"
 #: components/Blocks/Accordion/EditBlockWrapper
 msgid "delete"
+msgstr ""
+
+#. Default: "descending"
+#: overrideTranslations
+msgid "descendingTableSort"
 msgstr ""
 
 #. Default: "Testo per il link al dettaglio"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -1079,6 +1079,11 @@ msgstr ""
 msgid "appStoreLink"
 msgstr ""
 
+#. Default: "ascending"
+#: overrideTranslations
+msgid "ascendingTableSort"
+msgstr ""
+
 #. Default: "Allegato"
 #: components/Cards/CardFile/CardFile
 msgid "attachment"
@@ -1727,6 +1732,11 @@ msgstr ""
 #. Default: "delete"
 #: components/Blocks/Accordion/EditBlockWrapper
 msgid "delete"
+msgstr ""
+
+#. Default: "descending"
+#: overrideTranslations
+msgid "descendingTableSort"
 msgstr ""
 
 #. Default: "Testo per il link al dettaglio"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1072,6 +1072,11 @@ msgstr ""
 msgid "appStoreLink"
 msgstr ""
 
+#. Default: "ascending"
+#: overrideTranslations
+msgid "ascendingTableSort"
+msgstr "ordina dall'alto"
+
 #. Default: "Allegato"
 #: components/Cards/CardFile/CardFile
 msgid "attachment"
@@ -1721,6 +1726,11 @@ msgstr ""
 #: components/Blocks/Accordion/EditBlockWrapper
 msgid "delete"
 msgstr "elimina"
+
+#. Default: "descending"
+#: overrideTranslations
+msgid "descendingTableSort"
+msgstr "ordina dal basso"
 
 #. Default: "Testo per il link al dettaglio"
 #: config/blocks/listing/ListingOptions/utils

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1075,7 +1075,7 @@ msgstr ""
 #. Default: "ascending"
 #: overrideTranslations
 msgid "ascendingTableSort"
-msgstr "ordina dall'alto"
+msgstr "ordine crescente"
 
 #. Default: "Allegato"
 #: components/Cards/CardFile/CardFile
@@ -1730,7 +1730,7 @@ msgstr "elimina"
 #. Default: "descending"
 #: overrideTranslations
 msgid "descendingTableSort"
-msgstr "ordina dal basso"
+msgstr "ordine discendente"
 
 #. Default: "Testo per il link al dettaglio"
 #: config/blocks/listing/ListingOptions/utils

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2025-03-24T09:51:21.877Z\n"
+"POT-Creation-Date: 2025-03-26T11:51:30.855Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -1074,6 +1074,11 @@ msgstr ""
 msgid "appStoreLink"
 msgstr ""
 
+#. Default: "ascending"
+#: overrideTranslations
+msgid "ascendingTableSort"
+msgstr ""
+
 #. Default: "Allegato"
 #: components/Cards/CardFile/CardFile
 msgid "attachment"
@@ -1722,6 +1727,11 @@ msgstr ""
 #. Default: "delete"
 #: components/Blocks/Accordion/EditBlockWrapper
 msgid "delete"
+msgstr ""
+
+#. Default: "descending"
+#: overrideTranslations
+msgid "descendingTableSort"
 msgstr ""
 
 #. Default: "Testo per il link al dettaglio"

--- a/src/customizations/@plone/volto-slate/blocks/Table/TableBlockView.jsx
+++ b/src/customizations/@plone/volto-slate/blocks/Table/TableBlockView.jsx
@@ -5,8 +5,9 @@
  * - aggiunto aria-sort per indicare la direzione dell’ordinamento (ascending o descending). Se la colonna non è ordinata, usa aria-sort="none".
  * - role="columnheader": Aggiunge il ruolo di intestazione di colonna.
  * - Accessibilità tastiera (onKeyDown) per permette l’ordinamento con Enter o Spazio.
- * tabIndex={0} per rende la cella interattiva tramite tastiera.
+ * - tabIndex={0} per rende la cella interattiva tramite tastiera.
  */
+
 import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Table } from 'semantic-ui-react';
@@ -15,6 +16,18 @@ import {
   serializeNodesToText,
 } from '@plone/volto-slate/editor/render';
 import { Node } from 'slate';
+import { useIntl, defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+  ascendingTableSort: {
+    id: 'ascendingTableSort',
+    defaultMessage: 'ascending',
+  },
+  descendingTableSort: {
+    id: 'descendingTableSort',
+    defaultMessage: 'descending',
+  },
+});
 
 /**
  * Slate Table block's View class.
@@ -26,6 +39,8 @@ const View = ({ data }) => {
     column: null,
     direction: null,
   });
+
+  const intl = useIntl();
 
   const { table } = data;
   const {
@@ -77,10 +92,11 @@ const View = ({ data }) => {
       column: index,
       direction:
         prevState.column !== index
-          ? 'ascending'
-          : prevState.direction === 'ascending'
-            ? 'descending'
-            : 'ascending',
+          ? intl.formatMessage(messages.ascendingTableSort)
+          : prevState.direction ===
+              intl.formatMessage(messages.ascendingTableSort)
+            ? intl.formatMessage(messages.descendingTableSort)
+            : intl.formatMessage(messages.ascendingTableSort),
     }));
   };
 

--- a/src/customizations/@plone/volto-slate/blocks/Table/TableBlockView.jsx
+++ b/src/customizations/@plone/volto-slate/blocks/Table/TableBlockView.jsx
@@ -1,0 +1,161 @@
+/**
+ * Slate Table block's View component.
+ * @module volto-slate/blocks/Table/View
+ * Customizations:
+ * - aggiunto aria-sort per indicare la direzione dell’ordinamento (ascending o descending). Se la colonna non è ordinata, usa aria-sort="none".
+ * - role="columnheader": Aggiunge il ruolo di intestazione di colonna.
+ * - Accessibilità tastiera (onKeyDown) per permette l’ordinamento con Enter o Spazio.
+ * tabIndex={0} per rende la cella interattiva tramite tastiera.
+ */
+import React, { useState, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { Table } from 'semantic-ui-react';
+import {
+  serializeNodes,
+  serializeNodesToText,
+} from '@plone/volto-slate/editor/render';
+import { Node } from 'slate';
+
+/**
+ * Slate Table block's View class.
+ * @class View
+ * @param {object} data The table data to render as a table.
+ */
+const View = ({ data }) => {
+  const [state, setState] = useState({
+    column: null,
+    direction: null,
+  });
+
+  const { table } = data;
+  const {
+    rows,
+    fixed,
+    compact,
+    basic,
+    celled,
+    inverted,
+    striped,
+    sortable,
+    hideHeaders,
+  } = table;
+
+  const headers = useMemo(() => rows?.[0]?.cells || [], [rows]);
+  const rowsData = useMemo(() => {
+    return (
+      rows?.slice(1).map((row) =>
+        row.cells.map((cell) => ({
+          ...cell,
+          value:
+            cell.value && Node.string({ children: cell.value }).length > 0
+              ? serializeNodes(cell.value)
+              : '\u00A0',
+          valueText:
+            cell.value && Node.string({ children: cell.value }).length > 0
+              ? serializeNodesToText(cell.value)
+              : '\u00A0',
+        })),
+      ) || []
+    );
+  }, [rows]);
+
+  const sortedRows = useMemo(() => {
+    if (state.column === null) return rowsData;
+    return [...rowsData].sort((a, b) => {
+      const aText = a[state.column].valueText;
+      const bText = b[state.column].valueText;
+      const isAscending = state.direction === 'ascending';
+      if (isAscending ? aText < bText : aText > bText) return -1;
+      if (isAscending ? aText > bText : aText < bText) return 1;
+      return 0;
+    });
+  }, [state, rowsData]);
+
+  const handleSort = (index) => {
+    if (!sortable) return;
+    setState((prevState) => ({
+      column: index,
+      direction:
+        prevState.column !== index
+          ? 'ascending'
+          : prevState.direction === 'ascending'
+            ? 'descending'
+            : 'ascending',
+    }));
+  };
+
+  return (
+    <>
+      {table && (
+        <Table
+          fixed={fixed}
+          compact={compact}
+          basic={basic ? 'very' : false}
+          celled={celled}
+          inverted={inverted}
+          striped={striped}
+          sortable={sortable}
+          className="slate-table-block"
+        >
+          {!hideHeaders && (
+            <Table.Header>
+              <Table.Row>
+                {headers.map((cell, index) => (
+                  <Table.HeaderCell
+                    key={index}
+                    textAlign="left"
+                    verticalAlign="middle"
+                    sorted={state.column === index ? state.direction : null}
+                    aria-sort={
+                      state.column === index ? state.direction : 'none'
+                    }
+                    role="columnheader"
+                    onClick={() => handleSort(index)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleSort(index);
+                      }
+                    }}
+                    tabIndex={0}
+                  >
+                    {cell.value &&
+                    Node.string({ children: cell.value }).length > 0
+                      ? serializeNodes(cell.value)
+                      : '\u00A0'}
+                  </Table.HeaderCell>
+                ))}
+              </Table.Row>
+            </Table.Header>
+          )}
+          <Table.Body>
+            {sortedRows.map((row, rowIndex) => (
+              <Table.Row key={rowIndex}>
+                {row.map((cell, cellIndex) => (
+                  <Table.Cell
+                    key={cellIndex}
+                    textAlign="left"
+                    verticalAlign="middle"
+                  >
+                    {cell.value}
+                  </Table.Cell>
+                ))}
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      )}
+    </>
+  );
+};
+
+/**
+ * Property types.
+ * @property {Object} propTypes Property types.
+ * @static
+ */
+View.propTypes = {
+  data: PropTypes.objectOf(PropTypes.any).isRequired,
+};
+
+export default View;

--- a/src/customizations/volto/components/theme/View/View.jsx
+++ b/src/customizations/volto/components/theme/View/View.jsx
@@ -33,8 +33,8 @@ import config from '@plone/volto/registry';
 import SlotRenderer from '@plone/volto/components/theme/SlotRenderer/SlotRenderer';
 
 const sentryLibraries = {
-  Sentry: loadable.lib(
-    () => import(/* webpackChunkName: "s_entry-browser" */ '@sentry/browser'),
+  Sentry: loadable.lib(() =>
+    import(/* webpackChunkName: "s_entry-browser" */ '@sentry/browser'),
   ),
 };
 
@@ -287,7 +287,7 @@ class View extends Component {
       this.getViewByLayout() || this.getViewByType() || this.getViewDefault();
 
     return (
-      <div id="view">
+      <div id="view" tabIndex="-1">
         <ContentMetadataTags content={this.props.content} />
         <AlternateHrefLangs content={this.props.content} />
 

--- a/src/customizations/volto/components/theme/View/View.jsx
+++ b/src/customizations/volto/components/theme/View/View.jsx
@@ -33,8 +33,8 @@ import config from '@plone/volto/registry';
 import SlotRenderer from '@plone/volto/components/theme/SlotRenderer/SlotRenderer';
 
 const sentryLibraries = {
-  Sentry: loadable.lib(() =>
-    import(/* webpackChunkName: "s_entry-browser" */ '@sentry/browser'),
+  Sentry: loadable.lib(
+    () => import(/* webpackChunkName: "s_entry-browser" */ '@sentry/browser'),
   ),
 };
 
@@ -287,7 +287,7 @@ class View extends Component {
       this.getViewByLayout() || this.getViewByType() || this.getViewDefault();
 
     return (
-      <div id="view" tabIndex="-1">
+      <div id="view">
         <ContentMetadataTags content={this.props.content} />
         <AlternateHrefLangs content={this.props.content} />
 

--- a/src/overrideTranslations.jsx
+++ b/src/overrideTranslations.jsx
@@ -170,4 +170,12 @@ defineMessages({
     id: 'mainMenu',
     defaultMessage: 'Menù principale',
   },
+  ascendingTableSort: {
+    id: 'ascendingTableSort',
+    defaultMessage: 'ascending',
+  },
+  descendingTableSort: {
+    id: 'descendingTableSort',
+    defaultMessage: 'descending',
+  },
 });


### PR DESCRIPTION
 - aggiunto aria-sort per indicare la direzione dell’ordinamento (ascending o descending). Se la colonna non è ordinata, usa aria-sort="none".
 - role="columnheader": Aggiunge il ruolo di intestazione di colonna.
 - Accessibilità tastiera (onKeyDown) per permette l’ordinamento con Enter o Spazio.
 - tabIndex={0} per rende la cella interattiva tramite tastiera.

**Questo si può fare su Volto volendo