### PR TITLE
feat: Schema.org ComeFarePer

### DIFF
--- a/src/components/View/ComeFarePer/ComeFarePerSchemaOrg.jsx
+++ b/src/components/View/ComeFarePer/ComeFarePerSchemaOrg.jsx
@@ -1,0 +1,63 @@
+import { toPublicURL } from '@plone/volto/helpers';
+import {
+  SchemaOrg,
+  SchemaOrgUtils,
+  richTextHasContent,
+} from 'io-sanita-theme/helpers';
+
+const ComeFarePerSchemaOrg = ({ content }) => {
+  const siteTitle = SchemaOrgUtils.getSiteTitle();
+
+  let description = [];
+  let _yield = [];
+  let steps = content?.items?.filter((item) => item['@type'] === 'Step') ?? [];
+
+  //description
+  if (content.description) {
+    description.push(content.description);
+  }
+  if (content.sottotitolo) {
+    description.push(content.sottotitolo);
+  }
+
+  let schemaOrg = {
+    '@type': 'HowTo',
+    url: toPublicURL(content['@id']),
+  };
+
+  if (description.length > 0) {
+    schemaOrg.description = description.join('. ');
+  }
+
+  //yield -- The quantity that results by performing instructions. For example, a paper airplane, 10 personalized candles.
+  if (richTextHasContent(content.panoramica)) {
+    _yield.push(SchemaOrgUtils.fieldDataToPlainText(content.panoramica));
+  }
+  if (_yield.length > 0) {
+    schemaOrg.yield = _yield.join('. ');
+  }
+
+  if (richTextHasContent(content.come_fare)) {
+    schemaOrg.conditionsOfAccess = SchemaOrgUtils.fieldDataToPlainText(
+      content.come_fare,
+    );
+  }
+  if (richTextHasContent(content.a_chi_si_rivolge)) {
+    schemaOrg.audience = SchemaOrgUtils.fieldDataToPlainText(
+      content.a_chi_si_rivolge,
+    );
+  }
+
+  if (steps.length > 0) {
+    schemaOrg.step = content.come_fare.items.map((item) => {
+      return {
+        '@type': 'HowToStep',
+        //text: SchemaOrgUtils.fieldDataToPlainText(item),
+      };
+    });
+  }
+
+  return <SchemaOrg content={content} schema={schemaOrg} />;
+};
+
+export default ComeFarePerSchemaOrg;

--- a/src/components/View/ComeFarePer/ComeFarePerSchemaOrg.jsx
+++ b/src/components/View/ComeFarePer/ComeFarePerSchemaOrg.jsx
@@ -5,12 +5,16 @@ import {
   richTextHasContent,
 } from 'io-sanita-theme/helpers';
 
+import { useLoadSteps } from 'io-sanita-theme/components/View/ComeFarePer/Steps/helpers';
+import { positions } from 'slate';
+
 const ComeFarePerSchemaOrg = ({ content }) => {
   const siteTitle = SchemaOrgUtils.getSiteTitle();
 
   let description = [];
   let _yield = [];
   let steps = content?.items?.filter((item) => item['@type'] === 'Step') ?? [];
+  const { loadedSteps } = useLoadSteps(steps);
 
   //description
   if (content.description) {
@@ -48,12 +52,18 @@ const ComeFarePerSchemaOrg = ({ content }) => {
     );
   }
 
-  if (steps.length > 0) {
-    schemaOrg.step = content.come_fare.items.map((item) => {
-      return {
+  if (steps.length > 0 && Object.keys(loadedSteps).length === steps.length) {
+    schemaOrg.step = Object.keys(loadedSteps).map((id, index) => {
+      const step = loadedSteps[id];
+      const stepSchemaOrg = {
         '@type': 'HowToStep',
-        //text: SchemaOrgUtils.fieldDataToPlainText(item),
+        position: index + 1,
+        name: step.title ?? 'Step ' + (index + 1),
       };
+      if (richTextHasContent(step.testo)) {
+        stepSchemaOrg.text = SchemaOrgUtils.fieldDataToPlainText(step.testo);
+      }
+      return stepSchemaOrg;
     });
   }
 

--- a/src/components/View/ComeFarePer/ComeFarePerView.jsx
+++ b/src/components/View/ComeFarePer/ComeFarePerView.jsx
@@ -26,7 +26,9 @@ import {
   ComeFarePerComeFare,
   ComeFarePerApprofondimenti,
   ComeFarePerUlterioriInformazioni,
+  ComeFarePerSchemaOrg,
 } from 'io-sanita-theme/components/View/ComeFarePer';
+import { component } from 'design-react-kit/dist/types/Icon/assets/ItAndroidSquare';
 
 export const ComeFarePerViewSectionsOrder = [
   { /* DESCRIZIONE ESTESA (Panoramica) */ component: ComeFarePerDescrizione },
@@ -39,6 +41,7 @@ export const ComeFarePerViewSectionsOrder = [
       ComeFarePerUlterioriInformazioni,
   },
   { /* METADATA */ component: Metadata },
+  { /* SCHEMA ORG*/ component: ComeFarePerSchemaOrg },
 ];
 
 /**

--- a/src/components/View/ComeFarePer/ComeFarePerView.jsx
+++ b/src/components/View/ComeFarePer/ComeFarePerView.jsx
@@ -28,7 +28,6 @@ import {
   ComeFarePerUlterioriInformazioni,
   ComeFarePerSchemaOrg,
 } from 'io-sanita-theme/components/View/ComeFarePer';
-import { component } from 'design-react-kit/dist/types/Icon/assets/ItAndroidSquare';
 
 export const ComeFarePerViewSectionsOrder = [
   { /* DESCRIZIONE ESTESA (Panoramica) */ component: ComeFarePerDescrizione },

--- a/src/components/View/ComeFarePer/Steps/Steps.jsx
+++ b/src/components/View/ComeFarePer/Steps/Steps.jsx
@@ -6,8 +6,7 @@
 import React, { useState, useEffect } from 'react';
 import { useIntl, defineMessages } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { getContent, resetContent } from '@plone/volto/actions/content/content';
-import { flattenToAppURL } from '@plone/volto/helpers/Url/Url';
+
 import PropTypes from 'prop-types';
 import {
   richTextHasContent,
@@ -23,7 +22,7 @@ import {
 } from 'design-react-kit';
 import { Icon, CardPlace, CardContatti } from 'io-sanita-theme/components';
 import { Attachments } from 'io-sanita-theme/components/View/commons';
-
+import { useLoadSteps } from 'io-sanita-theme/components/View/ComeFarePer/Steps/helpers';
 import './steps.scss';
 
 const messages = defineMessages({
@@ -72,25 +71,7 @@ const Steps = ({ content, steps = [] }) => {
     setActiveItem('');
   }, [allOpen]);
 
-  const searchSteps = useSelector((state) => state.content?.subrequests);
-
-  // one request is made for every step
-  useEffect(() => {
-    steps.forEach((item) => {
-      const url = flattenToAppURL(item['@id']);
-      const loaded = searchSteps?.[url]?.loading || searchSteps?.[url]?.loaded;
-
-      if (!loaded) {
-        dispatch(getContent(url, null, url));
-      }
-    });
-
-    return () => {
-      steps.forEach((item) => {
-        dispatch(resetContent(flattenToAppURL(item['@id'])));
-      });
-    };
-  }, []);
+  const { loadedSteps } = useLoadSteps(steps);
 
   return steps.length > 0 ? (
     <div className="steps">
@@ -114,7 +95,7 @@ const Steps = ({ content, steps = [] }) => {
       </Button>
       <Accordion background="active">
         {steps.map((s, index) => {
-          const step = searchSteps[flattenToAppURL(s['@id'])]?.data ?? s;
+          const step = loadedSteps[s['@id']] ?? s;
           const itemIndex = index + 1;
           const toggleItem = () => {
             setActiveItem(activeItem !== itemIndex ? itemIndex : '');

--- a/src/components/View/ComeFarePer/Steps/helpers.js
+++ b/src/components/View/ComeFarePer/Steps/helpers.js
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { flattenToAppURL } from '@plone/volto/helpers/Url/Url';
+import { getContent, resetContent } from '@plone/volto/actions/content/content';
+
+export const useLoadSteps = (steps = []) => {
+  const dispatch = useDispatch();
+  const subrequests = useSelector((state) => state.content?.subrequests);
+  const [loadedSteps, setLoadedSteps] = useState({});
+
+  // one request is made for every step
+  useEffect(() => {
+    steps.forEach((item) => {
+      const url = flattenToAppURL(item['@id']);
+      const subrequest_id = item['@id'];
+      const requested =
+        subrequests?.[subrequest_id]?.loading ||
+        subrequests?.[subrequest_id]?.loaded;
+
+      if (!requested) {
+        dispatch(getContent(url, null, subrequest_id));
+      }
+    });
+
+    return () => {
+      steps.forEach((item) => {
+        dispatch(resetContent(subrequest_id));
+      });
+    };
+  }, []);
+
+  useEffect(() => {
+    steps.forEach((item) => {
+      const subrequest_id = item['@id'];
+      const step = subrequests?.[subrequest_id]?.data;
+      if (subrequests?.[subrequest_id]?.loaded && step) {
+        setLoadedSteps({ ...loadedSteps, [item['@id']]: step });
+      }
+    });
+  }, [subrequests]);
+
+  return { loadedSteps };
+};

--- a/src/components/View/ComeFarePer/index.js
+++ b/src/components/View/ComeFarePer/index.js
@@ -36,6 +36,11 @@ export const ComeFarePerApprofondimenti = loadable(() =>
     /* webpackChunkName: "ISComeFarePerView" */ 'io-sanita-theme/components/View/ComeFarePer/ComeFarePerApprofondimenti'
   ),
 );
+export const ComeFarePerSchemaOrg = loadable(() =>
+  import(
+    /* webpackChunkName: "ISComeFarePerView" */ 'io-sanita-theme/components/View/ComeFarePer/ComeFarePerSchemaOrg'
+  ),
+);
 export const Steps = loadable(() =>
   import(
     /* webpackChunkName: "ISComeFarePerView" */ 'io-sanita-theme/components/View/ComeFarePer/Steps/Steps'


### PR DESCRIPTION
implementato lo schema.org per il content-type ComeFarePer. 

Refactor della load degli step per poterla riutilizzare nello schema.org

<img width="2560" alt="Screenshot 2025-05-16 alle 10 15 13" src="https://github.com/user-attachments/assets/f00f8b96-26d8-438d-a930-ea64fec96e91" />

