### PR TITLE
fix: add word-break to tables

### DIFF
--- a/src/theme/io-sanita/_commons.scss
+++ b/src/theme/io-sanita/_commons.scss
@@ -1,0 +1,9 @@
+// Questo evita che le tabelle su control panel si allunghino
+body {
+  table {
+    th,
+    td {
+      word-break: break-word;
+    }
+  }
+}

--- a/src/theme/main.scss
+++ b/src/theme/main.scss
@@ -13,6 +13,7 @@
 @import './io-sanita/point-list';
 @import './io-sanita/tables';
 @import './io-sanita/login';
+@import './io-sanita/commons';
 @import './io-sanita/addons/volto-gdpr-privacy';
 @import './io-sanita/addons/volto-venue';
 @import './io-sanita/addons/volto-data-grid-widget';


### PR DESCRIPTION
Preso come riferimento: https://github.com/RedTurtle/design-comuni-plone-theme/blob/d81d73bd7d1bac9c9b63f2dfead4a10fec3a3e0b/src/theme/ItaliaTheme/Views/_common.scss#L10

@giuliaghisini @SaraBianchi  Non c'era un file chiamato "commons" su io-Sanità per il CSS, quindi non sono sicuro se questa modifica è su posto corretto.

<img width="1395" alt="Screenshot 2025-05-22 at 12 29 00" src="https://github.com/user-attachments/assets/c4c9d4a6-2f86-457b-ac38-de127960a7d2" />
