### PR TITLE
fix: set headlines for richtext

### DIFF
--- a/src/theme/io-sanita/components/blocks/_common.scss
+++ b/src/theme/io-sanita/components/blocks/_common.scss
@@ -21,6 +21,39 @@
     }
   }
 }
+#main-content-section.it-page-sections-container .richtext-blocks {
+  h2 {
+    font-size: 1.555rem;
+    line-height: 1.428;
+    font-weight: 600;
+  }
+
+  h3 {
+    font-size: 1.35rem;
+    line-height: 1.25;
+    font-weight: 600;
+  }
+
+  h4 {
+    font-size: 1.35rem;
+    line-height: 1.25;
+    font-weight: 600;
+    color: $gray-600;
+  }
+
+  h5 {
+    font-size: 1.35rem;
+    line-height: 1.25;
+    font-weight: 600;
+    color: $gray-500;
+  }
+
+  h6 {
+    font-size: 1.2rem;
+    line-height: 1.15;
+    font-weight: 400;
+  }
+}
 
 // .is-block-description {
 //   &,


### PR DESCRIPTION
Add a new set of sizes for the headlines added via text editor for contentypes
<img width="826" alt="Screenshot 2025-07-02 at 12 12 26" src="https://github.com/user-attachments/assets/e9681651-d05b-4d4d-ae3f-85df64a63b31" />
