### PR TITLE
fix: add spacing between search text and total results in SearchDetails

### DIFF
--- a/src/customizations/volto/components/manage/Blocks/Search/components/SearchDetails.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/components/SearchDetails.jsx
@@ -24,7 +24,7 @@ const SearchDetails = ({ total, text, as = 'p', data }) => {
             {intl.formatMessage(commonSearchBlockMessages.searchedFor, {
               em: (...chunks) => <em>{chunks}</em>,
               searchedtext: text,
-            })}
+            })}{' '}
           </>
         )}
         {data.showTotalResults && (


### PR DESCRIPTION
Fixed missing space between the “searched text” and the “total results” in the SearchDetails component. Previously, the texts were concatenated without a space.

<img width="397" height="151" alt="Screenshot 2025-07-29 at 14 49 05" src="https://github.com/user-attachments/assets/fc1c757f-7000-44e3-a3ce-c363543d111b" />
