### PR TITLE
feat: search table layout: sort / export csv+pdf

### DIFF
--- a/src/components/Blocks/Listing/Table/TableTemplate.jsx
+++ b/src/components/Blocks/Listing/Table/TableTemplate.jsx
@@ -95,22 +95,12 @@ const TableTemplate = (props) => {
                     const widget_props = {
                       behavior: field_properties.behavior,
                     };
-                    switch (c.field) {
-                      case 'apertura_bando':
-                      case 'chiusura_procedimento_bando':
-                      case 'scadenza_domande_bando':
-                      case 'scadenza_bando':
-                        widget_props.format = 'DD MMM yyyy';
-                        break;
-                      default:
-                        break;
-                    }
-                    // rimuove ora, se non valorizzata
+                      // rimuove ora, se non valorizzata
                     if (
                       field_properties.widget === 'datetime' &&
                       item[c.field]?.indexOf('T00:00') > 0
                     ) {
-                      widget_props.format = 'DD MMM yyyy';
+                      widget_props.format = 'DD/MM/yyyy';
                     }
                     if (field_properties.vocabulary) {
                       widget_props.vocabulary =

--- a/src/components/Blocks/Listing/Table/TableTemplate.jsx
+++ b/src/components/Blocks/Listing/Table/TableTemplate.jsx
@@ -95,6 +95,10 @@ const TableTemplate = (props) => {
                     const widget_props = {
                       behavior: field_properties.behavior,
                     };
+                    if (field_properties.widget === 'datetime') {
+                      widget_props.format = 'DD/MM/yyyy HH:MM';
+                    }
+                    // per questi campi si è deciso dii non pubblicare ora:minuti
                     switch (c.field) {
                       case 'apertura_bando':
                       case 'chiusura_procedimento_bando':

--- a/src/components/Blocks/Listing/Table/TableTemplate.jsx
+++ b/src/components/Blocks/Listing/Table/TableTemplate.jsx
@@ -95,7 +95,17 @@ const TableTemplate = (props) => {
                     const widget_props = {
                       behavior: field_properties.behavior,
                     };
-                      // rimuove ora, se non valorizzata
+                    switch (c.field) {
+                      case 'apertura_bando':
+                      case 'chiusura_procedimento_bando':
+                      case 'scadenza_domande_bando':
+                      case 'scadenza_bando':
+                        widget_props.format = 'DD/MM/yyyy';
+                        break;
+                      default:
+                        break;
+                    }
+                    // rimuove ora, se non valorizzata
                     if (
                       field_properties.widget === 'datetime' &&
                       item[c.field]?.indexOf('T00:00') > 0

--- a/src/components/Blocks/Listing/Table/table-templates.scss
+++ b/src/components/Blocks/Listing/Table/table-templates.scss
@@ -1,3 +1,8 @@
+// XXX: workaround per template search con tabella e fltri con faccette laterali in edit
+body.cms-ui.has-toolbar.has-sidebar .public-ui .table-template .px-0.container {
+  width: 100% !important;
+}
+
 .table-template {
   table.table {
     th {

--- a/src/components/Blocks/Listing/Table/table-templates.scss
+++ b/src/components/Blocks/Listing/Table/table-templates.scss
@@ -1,7 +1,7 @@
 // XXX: workaround per template search con tabella e fltri con faccette laterali in edit
-body.cms-ui.has-toolbar.has-sidebar .public-ui .table-template .px-0.container {
-  width: 100% !important;
-}
+// body.cms-ui.has-toolbar.has-sidebar .public-ui .table-template .px-0.container {
+//   width: 100% !important;
+// }
 
 .table-template {
   table.table {

--- a/src/config/blocks/index.js
+++ b/src/config/blocks/index.js
@@ -287,6 +287,8 @@ export const applyIoSanitaBlocksConfig = (config) => {
     },
     search: {
       ...config.blocks.blocksConfig.search,
+      // filtro top non personalizzato / non funzionante con layout agid
+      variations: config.blocks.blocksConfig.search.variations.filter((v) => v.id !== 'facetsTopSide'), 
       templates: [
         ...listingVariations.map((v) => v.id).filter((v) => v !== 'carousel'),
       ],

--- a/src/customizations/volto/components/manage/Blocks/Search/SearchBlockView.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/SearchBlockView.jsx
@@ -4,7 +4,7 @@
     existing listing template styles
 */
 
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 
 import ListingBody from '@plone/volto/components/manage/Blocks/Listing/ListingBody';
 import { withBlockExtensions } from '@plone/volto/helpers/Extensions';
@@ -67,7 +67,9 @@ const applyDefaults = (data, root) => {
 };
 
 const SearchBlockView = (props) => {
-  const { data, searchData, mode = 'view', variation } = props;
+  console.log(props);  
+
+  const { data, searchData, mode = 'view', variation, path, id } = props;
 
   const Layout =
     variation?.view ||
@@ -93,10 +95,27 @@ const SearchBlockView = (props) => {
 
   const { variations } = config.blocks.blocksConfig.listing;
   const listingBodyVariation = variations.find(({ id }) => id === selectedView);
+
+  // TODO: useEffect ?
+  const downloadCsvUrl = __CLIENT__ && `${path}/searchblock/@@download/${id}/download.csv?${new URLSearchParams({
+    ...props.facets,
+    sort_on: props.sortOn,
+    sort_order: props.sortOrder,
+  })}`;
+  const downloadPdfUrl = __CLIENT__ && `${path}/searchblock/@@download/${id}/download.pdf?${new URLSearchParams({
+    ...props.facets,
+    sort_on: props.sortOn,
+    sort_order: props.sortOrder,
+  })}`;
+
   if (!Layout) return null;
 
+  
   return (
     <div className="block search">
+      {/* TODO: opzione per pulsante download csv/pdf */}
+      <a href={downloadCsvUrl} download>CSV</a>
+      <a href={downloadPdfUrl} download>PDF</a>
       <Layout
         {...props}
         isEditMode={mode === 'edit'}
@@ -111,6 +130,18 @@ const SearchBlockView = (props) => {
             path={props.path}
             isEditMode={mode === 'edit'}
           />
+
+          {/* TODO */}
+          {/* {downloadUrl && <>
+            <textarea style={{width: '100%'}} readOnly rows="10" value={downloadUrl}></textarea>
+            <br/>
+            <textarea style={{width: '100%'}} readOnly rows="10" value={
+              JSON.stringify({
+                query: searchData?.query, 
+                columns: data?.columns.map((c) => { return {field: c.field, ct: c.ct}})
+              }, null, 2)
+            }></textarea>
+          </>} */}
         </div>
       </Layout>
     </div>

--- a/src/customizations/volto/components/manage/Blocks/Search/SearchBlockView.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/SearchBlockView.jsx
@@ -138,7 +138,7 @@ const SearchBlockView = (props) => {
             isEditMode={mode === 'edit'}
           />
           {downloadUrl && data?.showDownloadActions && (
-            <div style={{ textAlign: 'right' }}>
+            <div class="text-right">
               {intl.formatMessage(messages.downloadInFormat)}:{' '}
               <a
                 href={downloadUrl.replace('__FORMAT__', 'csv')}

--- a/src/customizations/volto/components/manage/Blocks/Search/SearchBlockView.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/SearchBlockView.jsx
@@ -123,8 +123,6 @@ const SearchBlockView = (props) => {
 
   return (
     <div className="block search">
-      {/* TODO: opzione per pulsante download csv/pdf */}
-      {/* <pre>{JSON.stringify(props, null, 2)}</pre> */}
       <Layout
         {...props}
         isEditMode={mode === 'edit'}
@@ -139,26 +137,28 @@ const SearchBlockView = (props) => {
             path={props.path}
             isEditMode={mode === 'edit'}
           />
-          <div style={{ textAlign: 'right' }}>
-            {intl.formatMessage(messages.downloadInFormat)}:{' '}
-            <a
-              href={downloadUrl.replace('__FORMAT__', 'csv')}
-              download
-              className="btn btn-xs btn-primary inline-link"
-              disabled={!downloadUrl}
-            >
-              CSV
-            </a>{' '}
-            <a
-              href={downloadUrl.replace('__FORMAT__', 'pdf')}
-              download
-              className="btn btn-xs btn-primary inline-link"
-              disabled={!downloadUrl}
-            >
-              PDF
-            </a>{' '}
-            {/* <a href={downloadUrl.replace('__FORMAT__', 'html')} className="btn btn-xs btn-primary inline-link">HTML</a> */}
-          </div>
+          {downloadUrl && data?.showDownloadActions && (
+            <div style={{ textAlign: 'right' }}>
+              {intl.formatMessage(messages.downloadInFormat)}:{' '}
+              <a
+                href={downloadUrl.replace('__FORMAT__', 'csv')}
+                download
+                className="btn btn-xs btn-primary inline-link"
+                disabled={!downloadUrl}
+              >
+                CSV
+              </a>{' '}
+              <a
+                href={downloadUrl.replace('__FORMAT__', 'pdf')}
+                download
+                className="btn btn-xs btn-primary inline-link"
+                disabled={!downloadUrl}
+              >
+                PDF
+              </a>
+              {/* <a href={downloadUrl.replace('__FORMAT__', 'html')} className="btn btn-xs btn-primary inline-link">HTML</a> */}
+            </div>
+          )}
         </div>
       </Layout>
     </div>

--- a/src/customizations/volto/components/manage/Blocks/Search/components/SearchDetails.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/components/SearchDetails.jsx
@@ -20,17 +20,17 @@ const SearchDetails = ({ total, text, as = 'p', data }) => {
     <El className="search-details" aria-live="polite">
       <>
         {text && (
-          <>
+          <div>
             {intl.formatMessage(commonSearchBlockMessages.searchedFor, {
               em: (...chunks) => <em>{chunks}</em>,
               searchedtext: text,
             })}
-          </>
-        )}
+          </div>
+        )}{' '}
         {data.showTotalResults && (
-          <>
+          <div>
             {intl.formatMessage(messages.searchResults)}: <b>{total}</b>
-          </>
+          </div>
         )}
       </>
     </El>

--- a/src/customizations/volto/components/manage/Blocks/Search/components/SearchDetails.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/components/SearchDetails.jsx
@@ -20,17 +20,17 @@ const SearchDetails = ({ total, text, as = 'p', data }) => {
     <El className="search-details" aria-live="polite">
       <>
         {text && (
-          <div>
+          <>
             {intl.formatMessage(commonSearchBlockMessages.searchedFor, {
               em: (...chunks) => <em>{chunks}</em>,
               searchedtext: text,
-            })}
-          </div>{' '}
+            })}{' '}
+          </>
         )}
         {data.showTotalResults && (
-          <div>
+          <>
             {intl.formatMessage(messages.searchResults)}: <b>{total}</b>
-          </div>
+          </>
         )}
       </>
     </El>

--- a/src/customizations/volto/components/manage/Blocks/Search/components/SortOn.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/components/SortOn.jsx
@@ -1,0 +1,85 @@
+/* CUSTOMIZATIONS:
+  - Agid styling
+*/
+import { defineMessages, useIntl } from 'react-intl';
+// import upSVG from '@plone/volto/icons/sort-up.svg';
+// import downSVG from '@plone/volto/icons/sort-down.svg';
+// import { Container, Row, Col, Icon } from 'design-react-kit';
+import { SelectInput } from 'io-sanita-theme/components';
+
+const messages = defineMessages({
+  noSelection: {
+    id: 'No selection',
+    defaultMessage: 'No selection',
+  },
+  sortOn: {
+    id: 'Sort on',
+    defaultMessage: 'Sort on',
+  },
+  ascending: {
+    id: 'Ascending',
+    defaultMessage: 'Ascending',
+  },
+  descending: {
+    id: 'Descending',
+    defaultMessage: 'Descending',
+  },
+  sortedOn: {
+    id: 'Sorted on',
+    defaultMessage: 'Sorted on',
+  },
+});
+
+const SortOn = (props) => {
+  const {
+    data = {},
+    sortOn = null,
+    sortOrder = null,
+    setSortOn,
+    setSortOrder,
+    isEditMode,
+    querystring = {},
+  } = props;
+
+  const intl = useIntl();
+  const sortableOptions = data?.columns
+    ? [
+        { value: 'sortable_title', label: 'Titolo' },
+        ...data?.columns?.map((f) => {
+          return { value: f.field, label: f.title };
+        }),
+      ].filter((o) => querystring?.['indexes']?.[o.value]?.sortable)
+    : [{ value: 'sortable_title', label: 'Titolo' }];
+
+  const sortOrderOptions = [
+    { value: 'ascending', label: intl.formatMessage(messages.ascending) },
+    { value: 'descending', label: intl.formatMessage(messages.descending) },
+  ];
+
+  return (
+    <div className="pt-4">
+      <h6>{intl.formatMessage(messages.sortOn)}</h6>
+      {/* <pre>{JSON.stringify(searchData, null,2)}</pre> */}
+      {/* <pre>{JSON.stringify(data.columns, null,2)}</pre> */}
+      {/* <pre>{sortOn} {sortOrder}</pre> */}
+      <div className="pt-2">
+        <SelectInput
+          id="sortOn"
+          value={sortableOptions.find((o) => o.value === sortOn)}
+          onChange={(opt) => setSortOn(opt.value)}
+          options={sortableOptions}
+        />
+      </div>
+      <div className="pt-2">
+        <SelectInput
+          id="sortOrder"
+          value={sortOrderOptions.find((o) => o.value === sortOrder)}
+          onChange={(opt) => setSortOrder(opt.value)}
+          options={sortOrderOptions}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SortOn;

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
@@ -38,10 +38,10 @@ const LeftColumnFacets = (props) => {
   } = props;
   const { showSearchButton } = data;
   const isLive = !showSearchButton;
-  const showColumn =
+  const showColumn = !isEditMode && (
     data.columnTextTitle ||
     richTextHasContent(data.columnText) ||
-    data?.facets?.length > 0;
+    data?.facets?.length > 0);
   return (
     <div className="full-width bg-primary-lightest">
       <Container

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
@@ -7,6 +7,7 @@ import {
   SearchDetails,
   Facets,
   FilterList,
+  SortOn,
 } from '@plone/volto/components/manage/Blocks/Search/components';
 import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
 import { Container, Row, Col, Icon } from 'design-react-kit';
@@ -25,6 +26,8 @@ const LeftColumnFacets = (props) => {
     totalItems,
     facets,
     setFacets,
+    sortOn,
+    sortOrder,
     onTriggerSearch,
     searchedText, // search text for previous search
     isEditMode,
@@ -35,11 +38,10 @@ const LeftColumnFacets = (props) => {
   } = props;
   const { showSearchButton } = data;
   const isLive = !showSearchButton;
-  // TODO: temporanea, il layout in edit è completamente sballato, per ora non la mettiamo
-  const showColumn = !isEditMode && (
+  const showColumn =
     data.columnTextTitle ||
     richTextHasContent(data.columnText) ||
-    data?.facets?.length > 0);
+    data?.facets?.length > 0;
   return (
     <div className="full-width bg-primary-lightest">
       <Container
@@ -96,6 +98,34 @@ const LeftColumnFacets = (props) => {
                   />
                 </div>
               )}
+              <div className="sort-views-wrapper">
+                {data.showSortOn && (
+                  <SortOn
+                    data={data}
+                    querystring={querystring}
+                    isEditMode={isEditMode}
+                    sortOrder={sortOrder}
+                    sortOn={sortOn}
+                    setSortOn={(sortOn) => {
+                      flushSync(() => {
+                        // setSortOn(sortOn);
+                        onTriggerSearch(searchedText || '', facets, sortOn);
+                      });
+                    }}
+                    setSortOrder={(sortOrder) => {
+                      flushSync(() => {
+                        // setSortOrder(sortOrder);
+                        onTriggerSearch(
+                          searchedText || '',
+                          facets,
+                          sortOn,
+                          sortOrder,
+                        );
+                      });
+                    }}
+                  />
+                )}
+              </div>
             </div>
           )}
 

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
@@ -35,10 +35,11 @@ const LeftColumnFacets = (props) => {
   } = props;
   const { showSearchButton } = data;
   const isLive = !showSearchButton;
-  const showColumn =
+  // TODO: temporanea, il layout in edit è completamente sballato, per ora non la mettiamo
+  const showColumn = !isEditMode && (
     data.columnTextTitle ||
     richTextHasContent(data.columnText) ||
-    data?.facets?.length > 0;
+    data?.facets?.length > 0);
   return (
     <div className="full-width bg-primary-lightest">
       <Container

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
@@ -1,7 +1,7 @@
 /* CUSTOMIZATIONS:
   - Agid styling
 */
-import React, {useMemo} from 'react';
+import React, { useMemo } from 'react';
 import {
   SearchInput,
   SearchDetails,
@@ -13,12 +13,20 @@ import { Container, Row, Col, Icon } from 'design-react-kit';
 import { flushSync } from 'react-dom';
 import { RichText, richTextHasContent } from 'io-sanita-theme/helpers';
 import { SelectInput } from 'io-sanita-theme/components';
+import { useIntl, defineMessages } from 'react-intl';
 
 const FacetWrapper = ({ children }) => (
   <Col basic className="facet pt-4">
     {children}
   </Col>
 );
+
+const messages = defineMessages({
+  searchBlockOrder: {
+    id: 'searchBlockOrder',
+    defaultMessage: 'Ordinamento',
+  },
+});
 
 const RightColumnFacets = (props) => {
   const {
@@ -39,28 +47,35 @@ const RightColumnFacets = (props) => {
   } = props;
   const { showSearchButton } = data;
   const isLive = !showSearchButton;
+  const intl = useIntl();
 
   // TODO: fare mapping sul nome corretto (esempio sortable_title)
-  const sortableOptions = useMemo(() => [
-      {value: 'sortable_title', label: 'Titolo'},
-      ...data?.columns?.map((f) => { return { value: f.field, label: f.title}})
-  ].filter((o) => querystring?.['indexes']?.[o.value]?.sortable),
-  [data?.columns, querystring]);  
+  const sortableOptions = useMemo(
+    () =>
+      [
+        { value: 'sortable_title', label: 'Titolo' },
+        ...data?.columns?.map((f) => {
+          return { value: f.field, label: f.title };
+        }),
+      ].filter((o) => querystring?.['indexes']?.[o.value]?.sortable),
+    [data?.columns, querystring],
+  );
 
   // TODO: traduzioni
   const sortOrderOptions = [
-    {value: 'ascending', label: 'Crescente'},
-    {value: 'descending', label: 'Decrescente'},
-  ];  
+    { value: 'ascending', label: 'Crescente' },
+    { value: 'descending', label: 'Decrescente' },
+  ];
 
   // TODO: filtro sopra non funziona affatto
-  // TODO: temporanea, il layout in edit è completamente sballato, per ora non la mettiamotes 
+  // TODO: temporanea, il layout in edit è completamente sballato, per ora non la mettiamotes
   //        è completamente duplicato
   // TODO: il codice tra RightColumnFacets e LeftColumnFca
-  const showColumn = !isEditMode && (
-    data.columnTextTitle ||
-    richTextHasContent(data.columnText) ||
-    data?.facets?.length > 0);
+  const showColumn =
+    !isEditMode &&
+    (data.columnTextTitle ||
+      richTextHasContent(data.columnText) ||
+      data?.facets?.length > 0);
   return (
     <div className="full-width bg-primary-lightest">
       <Container className="searchBlock-facets right-column-facets" stackable>
@@ -147,13 +162,13 @@ const RightColumnFacets = (props) => {
                 </div>
               )}
 
-              {data?.showOrderOptions &&
-                <div>
-                  <h6>Ordinamento</h6>
+              {data?.showOrderOptions && (
+                <div className="pt-4">
+                  <h6>{intl.formatMessage(messages.searchBlockOrder)}</h6>
                   {/* <pre>{JSON.stringify(searchData, null,2)}</pre> */}
                   {/* <pre>{JSON.stringify(data.columns, null,2)}</pre> */}
                   {/* <pre>{sortOn} {sortOrder}</pre> */}
-                  <div>
+                  <div className="pt-2">
                     <SelectInput
                       id="sortOn"
                       value={sortableOptions.find((o) => o.value === sortOn)}
@@ -162,25 +177,32 @@ const RightColumnFacets = (props) => {
                         flushSync(() => {
                           onTriggerSearch(undefined, undefined, opt.value);
                         });
-                      }}    
+                      }}
                       options={sortableOptions}
-                      />
+                    />
                   </div>
-                  <div>
+                  <div className="pt-2">
                     <SelectInput
                       id="sortOrder"
-                      value={sortOrderOptions.find((o) => o.value === sortOrder)}
+                      value={sortOrderOptions.find(
+                        (o) => o.value === sortOrder,
+                      )}
                       // placeholder={intl.formatMessage(messages.area_territoriale)}
                       onChange={(opt) => {
-                        flushSync(() => { 
-                          onTriggerSearch(undefined, undefined, undefined, opt.value);
+                        flushSync(() => {
+                          onTriggerSearch(
+                            undefined,
+                            undefined,
+                            undefined,
+                            opt.value,
+                          );
                         });
-                      }}    
+                      }}
                       options={sortOrderOptions}
-                      />
+                    />
                   </div>
                 </div>
-              }
+              )}
             </div>
           )}
         </Row>

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
@@ -26,8 +26,18 @@ const messages = defineMessages({
     id: 'searchBlockOrder',
     defaultMessage: 'Ordinamento',
   },
+  ascending: {
+    id: 'ascending',
+    defaultMessage: 'Ascending',
+  },
+  descending: {
+    id: 'descending',
+    defaultMessage: 'Descending',
+  }
 });
 
+// TODO: il codice tra RightColumnFacets e LeftColumnFca
+//        è completamente duplicato
 const RightColumnFacets = (props) => {
   const {
     children,
@@ -52,32 +62,27 @@ const RightColumnFacets = (props) => {
   // TODO: fare mapping sul nome corretto (esempio sortable_title)
   const sortableOptions = useMemo(
     () =>
-      data?.columns
-        ? [
-            { value: 'sortable_title', label: 'Titolo' },
-            ...data?.columns?.map((f) => {
-              return { value: f.field, label: f.title };
-            }),
-          ].filter((o) => querystring?.['indexes']?.[o.value]?.sortable)
-        : [{ value: 'sortable_title', label: 'Titolo' }],
+      data?.columns ? [
+        { value: 'sortable_title', label: 'Titolo' },
+        ...data?.columns?.map((f) => {
+          return { value: f.field, label: f.title };
+        }),
+      ].filter((o) => querystring?.['indexes']?.[o.value]?.sortable) : [{ value: 'sortable_title', label: 'Titolo' }    ],
     [data?.columns, querystring],
   );
 
-  // TODO: traduzioni
   const sortOrderOptions = [
-    { value: 'ascending', label: 'Crescente' },
-    { value: 'descending', label: 'Decrescente' },
+    { value: 'ascending', label: intl.formatMessage(messages.ascending) },
+    { value: 'descending', label: intl.formatMessage(messages.descending) },
   ];
 
-  // TODO: filtro sopra non funziona affatto
   // TODO: temporanea, il layout in edit è completamente sballato, per ora non la mettiamotes
-  // TODO: il codice tra RightColumnFacets e LeftColumnFca
-  //        è completamente duplicato
   const showColumn =
     !isEditMode &&
     (data.columnTextTitle ||
       richTextHasContent(data.columnText) ||
-      data?.facets?.length > 0);
+      data?.facets?.length > 0 ||
+      data?.showOrderOptions);
   return (
     <div className="full-width bg-primary-lightest">
       <Container className="searchBlock-facets right-column-facets" stackable>

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
@@ -52,12 +52,14 @@ const RightColumnFacets = (props) => {
   // TODO: fare mapping sul nome corretto (esempio sortable_title)
   const sortableOptions = useMemo(
     () =>
-      data?.columns && [
-        { value: 'sortable_title', label: 'Titolo' },
-        ...data?.columns?.map((f) => {
-          return { value: f.field, label: f.title };
-        }),
-      ].filter((o) => querystring?.['indexes']?.[o.value]?.sortable),
+      data?.columns
+        ? [
+            { value: 'sortable_title', label: 'Titolo' },
+            ...data?.columns?.map((f) => {
+              return { value: f.field, label: f.title };
+            }),
+          ].filter((o) => querystring?.['indexes']?.[o.value]?.sortable)
+        : [{ value: 'sortable_title', label: 'Titolo' }],
     [data?.columns, querystring],
   );
 

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
@@ -52,7 +52,7 @@ const RightColumnFacets = (props) => {
   // TODO: fare mapping sul nome corretto (esempio sortable_title)
   const sortableOptions = useMemo(
     () =>
-      [
+      data?.columns && [
         { value: 'sortable_title', label: 'Titolo' },
         ...data?.columns?.map((f) => {
           return { value: f.field, label: f.title };
@@ -69,8 +69,8 @@ const RightColumnFacets = (props) => {
 
   // TODO: filtro sopra non funziona affatto
   // TODO: temporanea, il layout in edit è completamente sballato, per ora non la mettiamotes
-  //        è completamente duplicato
   // TODO: il codice tra RightColumnFacets e LeftColumnFca
+  //        è completamente duplicato
   const showColumn =
     !isEditMode &&
     (data.columnTextTitle ||

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
@@ -1,7 +1,7 @@
 /* CUSTOMIZATIONS:
   - Agid styling
 */
-import React from 'react';
+import React, {useMemo} from 'react';
 import {
   SearchInput,
   SearchDetails,
@@ -12,6 +12,7 @@ import UniversalLink from '@plone/volto/components/manage/UniversalLink/Universa
 import { Container, Row, Col, Icon } from 'design-react-kit';
 import { flushSync } from 'react-dom';
 import { RichText, richTextHasContent } from 'io-sanita-theme/helpers';
+import { SelectInput } from 'io-sanita-theme/components';
 
 const FacetWrapper = ({ children }) => (
   <Col basic className="facet pt-4">
@@ -26,6 +27,8 @@ const RightColumnFacets = (props) => {
     totalItems,
     facets,
     setFacets,
+    sortOn,
+    sortOrder,
     onTriggerSearch,
     searchedText, // search text for previous search
     isEditMode,
@@ -36,10 +39,28 @@ const RightColumnFacets = (props) => {
   } = props;
   const { showSearchButton } = data;
   const isLive = !showSearchButton;
-  const showColumn =
+
+  // TODO: fare mapping sul nome corretto (esempio sortable_title)
+  const sortableOptions = useMemo(() => [
+      {value: 'sortable_title', label: 'Titolo'},
+      ...data?.columns?.map((f) => { return { value: f.field, label: f.title}})
+  ].filter((o) => querystring?.['indexes']?.[o.value]?.sortable),
+  [data?.columns, querystring]);  
+
+  // TODO: traduzioni
+  const sortOrderOptions = [
+    {value: 'ascending', label: 'Crescente'},
+    {value: 'descending', label: 'Decrescente'},
+  ];  
+
+  // TODO: filtro sopra non funziona affatto
+  // TODO: temporanea, il layout in edit è completamente sballato, per ora non la mettiamotes 
+  //        è completamente duplicato
+  // TODO: il codice tra RightColumnFacets e LeftColumnFca
+  const showColumn = !isEditMode && (
     data.columnTextTitle ||
     richTextHasContent(data.columnText) ||
-    data?.facets?.length > 0;
+    data?.facets?.length > 0);
   return (
     <div className="full-width bg-primary-lightest">
       <Container className="searchBlock-facets right-column-facets" stackable>
@@ -125,6 +146,41 @@ const RightColumnFacets = (props) => {
                   />
                 </div>
               )}
+
+              {data?.showOrderOptions &&
+                <div>
+                  <h6>Ordinamento</h6>
+                  {/* <pre>{JSON.stringify(searchData, null,2)}</pre> */}
+                  {/* <pre>{JSON.stringify(data.columns, null,2)}</pre> */}
+                  {/* <pre>{sortOn} {sortOrder}</pre> */}
+                  <div>
+                    <SelectInput
+                      id="sortOn"
+                      value={sortableOptions.find((o) => o.value === sortOn)}
+                      // placeholder={intl.formatMessage(messages.area_territoriale)}
+                      onChange={(opt) => {
+                        flushSync(() => {
+                          onTriggerSearch(undefined, undefined, opt.value);
+                        });
+                      }}    
+                      options={sortableOptions}
+                      />
+                  </div>
+                  <div>
+                    <SelectInput
+                      id="sortOrder"
+                      value={sortOrderOptions.find((o) => o.value === sortOrder)}
+                      // placeholder={intl.formatMessage(messages.area_territoriale)}
+                      onChange={(opt) => {
+                        flushSync(() => { 
+                          onTriggerSearch(undefined, undefined, undefined, opt.value);
+                        });
+                      }}    
+                      options={sortOrderOptions}
+                      />
+                  </div>
+                </div>
+              }
             </div>
           )}
         </Row>

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
@@ -1,19 +1,17 @@
 /* CUSTOMIZATIONS:
   - Agid styling
 */
-import React, { useMemo } from 'react';
 import {
   SearchInput,
   SearchDetails,
   Facets,
   FilterList,
+  SortOn,
 } from '@plone/volto/components/manage/Blocks/Search/components';
 import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
 import { Container, Row, Col, Icon } from 'design-react-kit';
 import { flushSync } from 'react-dom';
 import { RichText, richTextHasContent } from 'io-sanita-theme/helpers';
-import { SelectInput } from 'io-sanita-theme/components';
-import { useIntl, defineMessages } from 'react-intl';
 
 const FacetWrapper = ({ children }) => (
   <Col basic className="facet pt-4">
@@ -21,23 +19,6 @@ const FacetWrapper = ({ children }) => (
   </Col>
 );
 
-const messages = defineMessages({
-  searchBlockOrder: {
-    id: 'searchBlockOrder',
-    defaultMessage: 'Ordinamento',
-  },
-  ascending: {
-    id: 'ascending',
-    defaultMessage: 'Ascending',
-  },
-  descending: {
-    id: 'descending',
-    defaultMessage: 'Descending',
-  }
-});
-
-// TODO: il codice tra RightColumnFacets e LeftColumnFca
-//        è completamente duplicato
 const RightColumnFacets = (props) => {
   const {
     children,
@@ -57,32 +38,13 @@ const RightColumnFacets = (props) => {
   } = props;
   const { showSearchButton } = data;
   const isLive = !showSearchButton;
-  const intl = useIntl();
 
-  // TODO: fare mapping sul nome corretto (esempio sortable_title)
-  const sortableOptions = useMemo(
-    () =>
-      data?.columns ? [
-        { value: 'sortable_title', label: 'Titolo' },
-        ...data?.columns?.map((f) => {
-          return { value: f.field, label: f.title };
-        }),
-      ].filter((o) => querystring?.['indexes']?.[o.value]?.sortable) : [{ value: 'sortable_title', label: 'Titolo' }    ],
-    [data?.columns, querystring],
-  );
-
-  const sortOrderOptions = [
-    { value: 'ascending', label: intl.formatMessage(messages.ascending) },
-    { value: 'descending', label: intl.formatMessage(messages.descending) },
-  ];
-
-  // TODO: temporanea, il layout in edit è completamente sballato, per ora non la mettiamotes
   const showColumn =
-    !isEditMode &&
-    (data.columnTextTitle ||
-      richTextHasContent(data.columnText) ||
-      data?.facets?.length > 0 ||
-      data?.showOrderOptions);
+    data.columnTextTitle ||
+    richTextHasContent(data.columnText) ||
+    data?.facets?.length > 0 ||
+    data?.showOrderOptions;
+
   return (
     <div className="full-width bg-primary-lightest">
       <Container className="searchBlock-facets right-column-facets" stackable>
@@ -169,47 +131,34 @@ const RightColumnFacets = (props) => {
                 </div>
               )}
 
-              {data?.showOrderOptions && (
-                <div className="pt-4">
-                  <h6>{intl.formatMessage(messages.searchBlockOrder)}</h6>
-                  {/* <pre>{JSON.stringify(searchData, null,2)}</pre> */}
-                  {/* <pre>{JSON.stringify(data.columns, null,2)}</pre> */}
-                  {/* <pre>{sortOn} {sortOrder}</pre> */}
-                  <div className="pt-2">
-                    <SelectInput
-                      id="sortOn"
-                      value={sortableOptions.find((o) => o.value === sortOn)}
-                      // placeholder={intl.formatMessage(messages.area_territoriale)}
-                      onChange={(opt) => {
-                        flushSync(() => {
-                          onTriggerSearch(undefined, undefined, opt.value);
-                        });
-                      }}
-                      options={sortableOptions}
-                    />
-                  </div>
-                  <div className="pt-2">
-                    <SelectInput
-                      id="sortOrder"
-                      value={sortOrderOptions.find(
-                        (o) => o.value === sortOrder,
-                      )}
-                      // placeholder={intl.formatMessage(messages.area_territoriale)}
-                      onChange={(opt) => {
-                        flushSync(() => {
-                          onTriggerSearch(
-                            undefined,
-                            undefined,
-                            undefined,
-                            opt.value,
-                          );
-                        });
-                      }}
-                      options={sortOrderOptions}
-                    />
-                  </div>
-                </div>
-              )}
+              <div className="sort-views-wrapper">
+                {data.showSortOn && (
+                  <SortOn
+                    data={data}
+                    querystring={querystring}
+                    isEditMode={isEditMode}
+                    sortOrder={sortOrder}
+                    sortOn={sortOn}
+                    setSortOn={(sortOn) => {
+                      flushSync(() => {
+                        // setSortOn(sortOn);
+                        onTriggerSearch(searchedText || '', facets, sortOn);
+                      });
+                    }}
+                    setSortOrder={(sortOrder) => {
+                      flushSync(() => {
+                        // setSortOrder(sortOrder);
+                        onTriggerSearch(
+                          searchedText || '',
+                          facets,
+                          sortOn,
+                          sortOrder,
+                        );
+                      });
+                    }}
+                  />
+                )}
+              </div>
             </div>
           )}
         </Row>

--- a/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
@@ -39,11 +39,11 @@ const RightColumnFacets = (props) => {
   const { showSearchButton } = data;
   const isLive = !showSearchButton;
 
-  const showColumn =
+  const showColumn = !isEditMode && (
     data.columnTextTitle ||
     richTextHasContent(data.columnText) ||
     data?.facets?.length > 0 ||
-    data?.showOrderOptions;
+    data?.showOrderOptions);
 
   return (
     <div className="full-width bg-primary-lightest">

--- a/src/customizations/volto/components/manage/Blocks/Search/schema.js
+++ b/src/customizations/volto/components/manage/Blocks/Search/schema.js
@@ -123,6 +123,10 @@ const messages = defineMessages({
     id: 'Show total results',
     defaultMessage: 'Show total results',
   },
+  showOrderOptions: {
+    id: 'Show sort options',
+    defaultMessage: 'Show sort options',
+  },
   columnTextTitle: {
     id: 'columnTextTitle',
     defaultMessage: 'Intestazione della colonna',
@@ -282,6 +286,7 @@ const SearchSchema = ({ data = {}, intl }) => {
           // ...(data.showSearchInput ? ['searchInputPrompt'] : []),
           // ...(data.showSearchButton ? ['searchButtonLabel'] : []),
           'showTotalResults',
+          'showOrderOptions',
         ],
       },
     ],
@@ -305,6 +310,11 @@ const SearchSchema = ({ data = {}, intl }) => {
       showTotalResults: {
         type: 'boolean',
         title: intl.formatMessage(messages.showTotalResults),
+        default: true,
+      },
+      showOrderOptions: {
+        type: 'boolean',
+        title: intl.formatMessage(messages.showOrderOptions),
         default: true,
       },
       searchButtonLabel: {

--- a/src/customizations/volto/components/manage/Blocks/Search/schema.js
+++ b/src/customizations/volto/components/manage/Blocks/Search/schema.js
@@ -315,7 +315,7 @@ const SearchSchema = ({ data = {}, intl }) => {
       showOrderOptions: {
         type: 'boolean',
         title: intl.formatMessage(messages.showOrderOptions),
-        default: true,
+        default: false,
       },
       searchButtonLabel: {
         title: intl.formatMessage(messages.searchButtonLabel),

--- a/src/customizations/volto/components/manage/Blocks/Search/schema.js
+++ b/src/customizations/volto/components/manage/Blocks/Search/schema.js
@@ -123,9 +123,9 @@ const messages = defineMessages({
     id: 'Show total results',
     defaultMessage: 'Show total results',
   },
-  showOrderOptions: {
-    id: 'Show sort options',
-    defaultMessage: 'Show sort options',
+  showSortOn: {
+    id: 'Show sorting?',
+    defaultMessage: 'Show sorting?',
   },
   columnTextTitle: {
     id: 'columnTextTitle',
@@ -286,7 +286,7 @@ const SearchSchema = ({ data = {}, intl }) => {
           // ...(data.showSearchInput ? ['searchInputPrompt'] : []),
           // ...(data.showSearchButton ? ['searchButtonLabel'] : []),
           'showTotalResults',
-          'showOrderOptions',
+          'showSortOn',
         ],
       },
     ],
@@ -312,9 +312,9 @@ const SearchSchema = ({ data = {}, intl }) => {
         title: intl.formatMessage(messages.showTotalResults),
         default: true,
       },
-      showOrderOptions: {
+      showSortOn: {
         type: 'boolean',
-        title: intl.formatMessage(messages.showOrderOptions),
+        title: intl.formatMessage(messages.showSortOn),
         default: false,
       },
       searchButtonLabel: {

--- a/src/customizations/volto/helpers/Api/APIResourceWithAuth.js
+++ b/src/customizations/volto/helpers/Api/APIResourceWithAuth.js
@@ -1,0 +1,42 @@
+/**
+ * Original from @plone/volto 18.9.1
+ * 
+ * - querystring parameters are passed to the backend
+ * 
+ */
+
+import superagent from 'superagent';
+import config from '@plone/volto/registry';
+import { addHeadersFactory } from '@plone/volto/helpers/Proxy/Proxy';
+
+/**
+ * Get a resource image/file with authenticated (if token exist) API headers
+ * @function getAPIResourceWithAuth
+ * @param {Object} req Request object
+ * @return {string} The response with the image
+ */
+export const getAPIResourceWithAuth = (req) =>
+  new Promise((resolve, reject) => {
+    const { settings } = config;
+    const APISUFIX = settings.legacyTraverse ? '' : '/++api++';
+
+    let apiPath = '';
+    if (settings.internalApiPath && __SERVER__) {
+      apiPath = settings.internalApiPath;
+    } else if (__DEVELOPMENT__ && settings.devProxyToApiPath) {
+      apiPath = settings.devProxyToApiPath;
+    } else {
+      apiPath = settings.apiPath;
+    }
+    const request = superagent
+      .get(`${apiPath}${__DEVELOPMENT__ ? '' : APISUFIX}${req.path}`)
+      .query(req.query)
+      .maxResponseSize(settings.maxResponseSize)
+      .responseType('blob');
+    const authToken = req.universalCookies.get('auth_token');
+    if (authToken) {
+      request.set('Authorization', `Bearer ${authToken}`);
+    }
+    request.use(addHeadersFactory(req));
+    request.then(resolve).catch(reject);
+  });

--- a/src/customizations/volto/helpers/Api/APIResourceWithAuth.js
+++ b/src/customizations/volto/helpers/Api/APIResourceWithAuth.js
@@ -1,4 +1,5 @@
 /**
+CUSTOMIZATIONS: 
  * Original from @plone/volto 18.9.1
  * 
  * - querystring parameters are passed to the backend


### PR DESCRIPTION
* [x] aggiunto ordinamento per gli utenti (checkbox per abilitarlo), le colonne nella tendina 
      sono solo quelle marcate come "sortable" e presenti tra le coolonne visibili
* [x] le date nel datable è stato richiesto vengano pubblicate nella forma DD/MM/YYYY
* [x] querystring parameters are passed to the backend in the file/image middleware
* [x] leftcolumnfacets/rightcloumnsfacet in edit si sovrappongo alla tabella (nascosti quaando in editmode per ora), topfacets non aveva un'impllementazioen aggid e non funzionava (per ora l'ho rimesso dalle varianti disponibili)
      e leggermente disallineati. valutiamo se allineari o temporaneamente per io-sanita 
      rimuovere la scelta e lasciare solo la variante right
* [x] aggiunti link download che si portano in query l'ordnamento e i filtri scelti 
      dall'utente (server iosanita.contenttypes aggiornato

      
