### PR TITLE
fix: fixed b_size select filter and subsite parent header

### DIFF
--- a/src/components/Widgets/SearchFilters/SelectFilter.jsx
+++ b/src/components/Widgets/SearchFilters/SelectFilter.jsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { searchContent } from '@plone/volto/actions/search/search';
 import { getVocabulary } from '@plone/volto/actions/vocabularies/vocabularies';
 
-const SelectFilter = ({ options, value, id, onChange, placeholder }) => {
+const SelectFilter = ({ options, value, id, onChange, placeholder, b_size = -1 }) => {
   const dispatch = useDispatch();
 
   const state = useSelector((state) => {
@@ -46,7 +46,7 @@ const SelectFilter = ({ options, value, id, onChange, placeholder }) => {
         );
       }
     } else if (options.vocabulary) {
-      dispatch(getVocabulary({ vocabNameOrURL: options.vocabulary }));
+      dispatch(getVocabulary({ vocabNameOrURL: options.vocabulary, size: b_size }));
     }
   }, []);
 

--- a/src/theme/io-sanita/subsites/bootstrap-italia/custom/_header.scss
+++ b/src/theme/io-sanita/subsites/bootstrap-italia/custom/_header.scss
@@ -40,6 +40,10 @@
                 }
               }
             }
+            
+            .parent-site-menu {
+              display: none;
+            }
           }
         }
       }


### PR DESCRIPTION
- Aggiunto `b_size` nella SelectFilter nel caso in cui venga popolata da un vocabolario di tassonomie perchè non vogliamo limiti di item
- Sistemato header-parent-slim del sottosito che si vedeva al passaggio del mouse