### PR TITLE
fix: better lead image centering

### DIFF
--- a/src/theme/io-sanita/components/view/commons/_pageHeader.scss
+++ b/src/theme/io-sanita/components/view/commons/_pageHeader.scss
@@ -26,7 +26,7 @@
           margin: 0;
 
           img {
-            object-position: top;
+            object-position: center;
           }
         }
       }


### PR DESCRIPTION
before:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/58a27e60-aba8-4899-bec0-8cc6b744429a" />

after:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b30f7ce1-ee1a-48eb-8089-1f82853dc8d8" />
