### PR TITLE
fix: header sticky with no navbar

### DIFF
--- a/src/theme/_bootstrap-italia.scss
+++ b/src/theme/_bootstrap-italia.scss
@@ -160,8 +160,10 @@
   @import './bootstrap-italia/custom/headercenter';
   @import 'bootstrap-italia/src/scss/custom/headercentertheme';
   @import 'bootstrap-italia/src/scss/custom/headernavbar';
+
   @import 'bootstrap-italia/src/scss/custom/headernavbartheme';
   @import 'bootstrap-italia/src/scss/custom/header';
+  @import './bootstrap-italia/custom/header';
 
   // footer
   @import 'bootstrap-italia/src/scss/custom/footer';

--- a/src/theme/bootstrap-italia/custom/_header.scss
+++ b/src/theme/bootstrap-italia/custom/_header.scss
@@ -1,0 +1,19 @@
+.it-header-wrapper {
+  &.it-header-sticky {
+    &.is-sticky {
+      @include media-breakpoint-up(lg) {
+        .it-header-slim-wrapper,
+        .it-header-center-wrapper {
+          //queste regole, fanno in modo che se il sito non ha il menu, quando l'header è sticky mostra comunque l'header center, altrimenti non si vedrebbe nulla.
+          display: block;
+          &:has(~ .it-header-navbar-wrapper:not(:empty)) {
+            display: none;
+          }
+          &:has(~ .it-header-navbar-wrapper:empty) {
+            height: auto;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/theme/bootstrap-italia/custom/_header.scss
+++ b/src/theme/bootstrap-italia/custom/_header.scss
@@ -2,7 +2,6 @@
   &.it-header-sticky {
     &.is-sticky {
       @include media-breakpoint-up(lg) {
-        .it-header-slim-wrapper,
         .it-header-center-wrapper {
           //queste regole, fanno in modo che se il sito non ha il menu, quando l'header è sticky mostra comunque l'header center, altrimenti non si vedrebbe nulla.
           display: block;


### PR DESCRIPTION
Quando il sito non ha il menu (non viene volutamente configurato dal pannello di controllo) e si scrolla la pagina, l'header diventa sticky e normalmente mostra solo il menu. 
In questo caso non mostra nulla. 
Questo è un comportamento definito da bootstrap-italia, per il quale non ha senso avere siti senza menu. 

Ho fatto in modo che quando il menu è vuoto, rimane visibile e sticky la parte centrale dell'header. 