### PR TITLE
fix: video not cropped when aligned right/left

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione x.x.x (xx/xx/xxxx)
+
+### Fix
+
+- Sistemata l'altezza del blocco Video quando è allineato a destra o sinistra: il video non si riduce più in altezza quando viene riprodotto.
+
 ## Versione 2.24.0 (10/04/2026)
 
 ### Fix

--- a/src/theme/io-sanita/components/blocks/_video.scss
+++ b/src/theme/io-sanita/components/blocks/_video.scss
@@ -52,7 +52,7 @@
     }
   }
 
-  &.align.center iframe,
+  .video-inner iframe,
   &.full .video-inner.full-width iframe {
     position: absolute;
     top: 0;


### PR DESCRIPTION
video was cropped when clicked if it was aligned right/left