### PR TITLE
fix: show pdc description inside contact card

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,6 +49,7 @@
 - Rimossa la scritta "Servizio disponibile e prenotabile" dalla vista dettaglio del Servizio.
 - Creato componente dedicato per il badge di stato del Servizio, riutilizzato in tutte le viste (dettaglio, card, listing).
 - Rimosso il link dal titolo della card del Punto di contatto nei CT. Il titolo ora non è più cliccabile.
+- Mostrare il testo della descrizione del Punto di contatto all'interno della card Contatti
 
 ## Versione 2.24.0 (10/04/2026)
 

--- a/src/components/Cards/CardContatti/CardContatti.jsx
+++ b/src/components/Cards/CardContatti/CardContatti.jsx
@@ -39,10 +39,10 @@ const CardContatti = ({
               return pdc.valore ? (
                 <span key={index}>
                   <span className="pdc-type">{pdc.tipo_label || pdc.tipo}</span>
-                  {/* <span className="pdc-desc">
-                    {pdc.descrizione ? ` - ${pdc.descrizione}` : ''}:{' '}
-                  </span> */}
                   : <PuntoDiContattoValue value={pdc} />
+                  <span className="pdc-desc">
+                    {pdc.descrizione ? ` - ${pdc.descrizione}` : ''}
+                  </span>
                 </span>
               ) : (
                 <></>

--- a/src/components/Cards/CardContatti/cardContatti.scss
+++ b/src/components/Cards/CardContatti/cardContatti.scss
@@ -12,6 +12,7 @@
     span {
       flex: 1 1 100%;
       font-size: 0.8886rem;
+      word-break: break-word;
     }
 
     .pdc-type {


### PR DESCRIPTION
[US #74813](https://redturtle.tpondemand.com/RestUI/Board.aspx#page=profile&appConfig=eyJhY2lkIjoiMThENUVDNkNBQzgxQ0NGRTUyOTIxMDgyNUI5NUM4QTQifQ==&boardPopup=bug/74813/silent)

Removed commented code to show pdc description inside contact card and made adjustment to break long text