### PR TITLE
feat: rimosso circoscrizione (non usato), aggiunto distretto

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione 2.26.1 (29/04/2026)
+
+### Novità
+
+- Aggiunto distretto (opzionale) tra i campi degli indirizzi.
+
 ## Versione 2.26.0 (22/04/2026)
 
 ### Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-sanita-theme",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "description": "io-sanita-theme: Volto add-on",
   "main": "src/index.js",
   "license": "MIT",

--- a/src/components/View/Evento/EventoDove.jsx
+++ b/src/components/View/Evento/EventoDove.jsx
@@ -1,15 +1,14 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-
+import {
+  RichText,
+  RichTextSection,
+  hasGeolocation,
+  richTextHasContent,
+} from 'io-sanita-theme/helpers';
 import { defineMessages, useIntl } from 'react-intl';
 
-import {
-  RichTextSection,
-  richTextHasContent,
-  RichText,
-  hasGeolocation,
-} from 'io-sanita-theme/helpers';
 import { Locations } from 'io-sanita-theme/components/View/commons';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const messages = defineMessages({
   dove: {
@@ -28,7 +27,6 @@ const EventoDove = ({ content }) => {
     content?.zip_code?.length > 0 ||
     content?.city?.length > 0 ||
     content?.quartiere?.length > 0 ||
-    content?.circoscrizione?.length > 0 ||
     content?.country?.length > 0 ||
     richTextHasContent(content?.webinar) ? (
     <RichTextSection tag_id="dove" title={intl.formatMessage(messages.dove)}>

--- a/src/components/View/Farmacia/FarmaciaDove.jsx
+++ b/src/components/View/Farmacia/FarmaciaDove.jsx
@@ -1,8 +1,9 @@
-import PropTypes from 'prop-types';
 import { defineMessages, useIntl } from 'react-intl';
+
+import { Locations } from 'io-sanita-theme/components/View/commons';
+import PropTypes from 'prop-types';
 // import { CardPlace } from 'io-sanita-theme/components';
 import { RichTextSection } from 'io-sanita-theme/helpers';
-import { Locations } from 'io-sanita-theme/components/View/commons';
 
 const messages = defineMessages({
   dove: {
@@ -21,10 +22,6 @@ const messages = defineMessages({
     id: 'farmacia_localita',
     defaultMessage: 'Località',
   },
-  circoscrizione: {
-    id: 'farmacia_circoscrizione',
-    defaultMessage: 'Circoscrizione',
-  },
   quartiere: {
     id: 'farmacia_quartiere',
     defaultMessage: 'Quartiere',
@@ -40,108 +37,12 @@ const FarmaciaDove = ({ content }) => {
     content.city ||
     content.provincia ||
     content.country ||
-    content.circoscrizione ||
     content.quartiere ||
     content.area_territoriale?.title ||
     content.comune ||
     content.localita ? (
     <RichTextSection tag_id="dove" title={intl.formatMessage(messages.dove)}>
-      {/* <CardPlace
-        item={{
-          ...content,
-          city: content.comune,
-          province: content.provincia,
-          area_territoriale: content.area_territoriale?.title,
-          street: `${content.street} - ${content.localita}`,
-        }}
-        showDistance={false}
-        showMap={true}
-      /> */}
-
       <Locations content={content} />
-
-      {/* -- codice originale versione auslfe
-
-      <Card className="card card-teaser shadow mt-3 rounded mb-4" tag="div">
-        <Icon icon={'it-pin'} />
-        <CardBody>
-          <CardTitle tag="h5" className="card-title">
-            {content.title}
-          </CardTitle>
-          <CardText tag="div">
-            {content.area_territoriale && (
-              <p>
-                <strong>{`${intl.formatMessage(messages.area_territoriale)}: `}</strong>
-                {content.area_territoriale.title}
-              </p>
-            )}
-
-            {content.comune && (
-              <p>
-                <strong>{`${intl.formatMessage(messages.comune)}: `}</strong>
-                {content.comune}
-              </p>
-            )}
-
-            {content.localita && (
-              <p>
-                <strong>{`${intl.formatMessage(messages.localita)}: `}</strong>
-                {content.localita}
-              </p>
-            )}
-
-            <p>
-              {[content.street, content.city]
-                .filter((v) => v !== null)
-                .join(' - ')}
-              {(content.street || content.city) &&
-                (content.zip_code || content.country) &&
-                !content.provincia && <br />}
-
-              {content.provincia && ' (' + content.provincia + ')\n'}
-
-              {content.zip_code && content.country?.title
-                ? [content.zip_code, content.country?.title]
-                    .filter((v) => v !== null)
-                    .join(' - ')
-                : content.zip_code || content.country?.title}
-            </p>
-          </CardText>
-        </CardBody>
-      </Card>
-      {
-        content.geolocation?.latitude &&
-        content.geolocation?.longitude && (
-        <>{__CLIENT__ ?
-          <OSMMap
-            markers={[
-              {
-                latitude: content.geolocation.latitude,
-                longitude: content.geolocation.longitude,
-                title: content.title,
-              },
-            ]}
-            mapOptions={{
-              scrollWheelZoom: false,
-              // tap: false,
-              // dragging: false,
-            }}
-          />:<div>Loading...</>}</>
-        )}
-      {content.circoscrizione && (
-        <div className="circoscrizione">
-          <h5 className="mt-3">
-            {intl.formatMessage(messages.circoscrizione)}:
-          </h5>
-          <div className="text-serif">{content.circoscrizione}</div>
-        </div>
-      )}
-      {content.quartiere && (
-        <div className="quartiere">
-          <h5 className="mt-3">{intl.formatMessage(messages.quartiere)}:</h5>
-          <div className="text-serif">{content.quartiere}</div>
-        </div>
-      )} */}
     </RichTextSection>
   ) : (
     <></>

--- a/src/components/View/Struttura/StrutturaDove.jsx
+++ b/src/components/View/Struttura/StrutturaDove.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { defineMessages, useIntl } from 'react-intl';
 import { RichTextSection, hasGeolocation } from 'io-sanita-theme/helpers';
+import { defineMessages, useIntl } from 'react-intl';
+
 import { Locations } from 'io-sanita-theme/components/View/commons';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const messages = defineMessages({
   dove: {
@@ -20,7 +21,6 @@ const StrutturaDove = ({ content }) => {
     content?.zip_code?.length > 0 ||
     content?.city?.length > 0 ||
     content?.quartiere?.length > 0 ||
-    content?.circoscrizione?.length > 0 ||
     content?.country?.length > 0 ? (
     <RichTextSection tag_id="dove" title={intl.formatMessage(messages.dove)}>
       <Locations content={content} />

--- a/src/components/View/UOView/UODove.jsx
+++ b/src/components/View/UOView/UODove.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { defineMessages, useIntl } from 'react-intl';
 import { RichTextSection, hasGeolocation } from 'io-sanita-theme/helpers';
+import { defineMessages, useIntl } from 'react-intl';
+
 import { Locations } from 'io-sanita-theme/components/View/commons';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const messages = defineMessages({
   dove: {
@@ -21,7 +22,6 @@ const UODove = ({ content }) => {
     content?.zip_code?.length > 0 ||
     content?.city?.length > 0 ||
     content?.quartiere?.length > 0 ||
-    content?.circoscrizione?.length > 0 ||
     content?.country?.length > 0 ? (
     <RichTextSection tag_id="luoghi" title={intl.formatMessage(messages.dove)}>
       {/* INDIRIZZI E STRUTTURE */}

--- a/src/components/View/commons/Locations/Locations.jsx
+++ b/src/components/View/commons/Locations/Locations.jsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import omit from 'lodash/omit';
-import { Row, Col } from 'design-react-kit';
-import { LocationsMap } from 'io-sanita-theme/components/View/commons';
+import { Col, Row } from 'design-react-kit';
+
 import { CardPlace } from 'io-sanita-theme/components';
+import { LocationsMap } from 'io-sanita-theme/components/View/commons';
+import PropTypes from 'prop-types';
+import React from 'react';
+import omit from 'lodash/omit';
 
 /**
  * Locations view component class.
@@ -18,8 +19,7 @@ const Locations = ({ content = {}, locations = [] }) => {
     content.street ||
     content.city ||
     content.zip_code ||
-    content.quartiere ||
-    content.circoscrizione
+    content.quartiere
   ) {
     location_items.push(omit(content, ['@id']));
   }

--- a/src/helpers/Address/Address.jsx
+++ b/src/helpers/Address/Address.jsx
@@ -1,8 +1,8 @@
+import { Icon } from 'io-sanita-theme/components';
 /*TODO:
 - implementare il calcolo della distanza
 */
 import React from 'react';
-import { Icon } from 'io-sanita-theme/components';
 
 const Address = ({ item, showAddress = true, showDistance, tag }) => {
   const address_row_2 = ['zip_code', 'city', 'province']
@@ -15,6 +15,7 @@ const Address = ({ item, showAddress = true, showDistance, tag }) => {
     typeof item.area_territoriale === 'object'
       ? item.area_territoriale && item.area_territoriale.value
       : item.area_territoriale;
+  const distretto = item.distretto;
 
   return item.street?.length > 0 || address_row_2.length ? (
     <>
@@ -31,6 +32,12 @@ const Address = ({ item, showAddress = true, showDistance, tag }) => {
             <>
               <br />
               {address_row_2}
+            </>
+          )}
+          {distretto && (
+            <>
+              <br />
+              {item.distretto}
             </>
           )}
         </AddressWrapperTag>

--- a/src/helpers/Item/item.js
+++ b/src/helpers/Item/item.js
@@ -38,6 +38,8 @@ export const getItemIcon = (item) => {
 export const hasGeolocation = (item) => {
   return (
     item?.geolocation &&
+    item?.geolocation?.latitude &&
+    item?.geolocation?.longitude &&
     item?.geolocation?.latitude !== 0 &&
     item?.geolocation?.longitude !== 0
   );

--- a/src/stories/Cards/mock.js
+++ b/src/stories/Cards/mock.js
@@ -34,7 +34,7 @@ export const ExampleStrrutturaItem = {
     title: 'Ambulatori dei medici di base',
   },
   effective: '2024-04-17T10:40:05+00:00',
-  circoscrizione: null,
+  dsistretto: 'Distretto 1',
   city: 'Palazzuolo sul senio',
   country: {
     title: 'Italia',


### PR DESCRIPTION
rif.: https://github.com/RedTurtle/iosanita.contenttypes/pull/30

circoscrizione era nelle condizioni, ma mai mostrato, inoltre nella ASL non è mai emersa la necessità dell`informazione "circoscrizione" (informazione più legata ad amministrazioni come comuni).

D'altra parte invece lìnformazione `distretto` è stata più volte richiesta da molte ASL.

\cc @NicolaZivago 