### PR TITLE
fix: listen to path when searching servizi o procedure

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- Sistemato il blocco "Cerca servizi e procedure" in modo tale che consideri il path all'interno del quale fare la ricerca.
+
 ## Versione 2.28.0 (05/05/2026)
 
 ### Migliorie

--- a/src/components/Blocks/SearchServiziProcedure/Body.jsx
+++ b/src/components/Blocks/SearchServiziProcedure/Body.jsx
@@ -118,6 +118,14 @@ const Body = ({ data, id, path, properties, inEditMode }) => {
       },
     ];
 
+    if (data.path && data.path[0]) {
+      query.push({
+        i: 'path',
+        o: 'plone.app.querystring.operation.string.absolutePath',
+        v: flattenToAppURL(data.path[0]['@id']),
+      });
+    }
+
     // user filters
     if (filters.searchableText?.length > 0) {
       query.push({


### PR DESCRIPTION
[US#75512](https://redturtle.tpondemand.com/RestUI/Board.aspx#page=profile&appConfig=eyJhY2lkIjoiM0YwMDA1MEY3Mzg3NjUxOEU4QTcxN0NGODgzMThEQUEifQ==&boardPopup=bug/75512/silent)

Added logic to listen to path when searching for servizi o procedure