### PR TITLE
fix: handle no geolocation in person card avoiding to show 0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,6 +46,7 @@
 ### Fix
 
 - Sistemato il blocco "Cerca servizi e procedure" in modo tale che consideri il path all'interno del quale fare la ricerca.
+- Gestita la mancanza di geolocalizzazione all'interno del CT Persona in modo tale da non mostrare 0 all'interno della card Persona quando assente.
 
 ## Versione 2.28.0 (05/05/2026)
 

--- a/src/helpers/Item/item.js
+++ b/src/helpers/Item/item.js
@@ -36,11 +36,13 @@ export const getItemIcon = (item) => {
 };
 
 export const hasGeolocation = (item) => {
-  return (
-    item?.geolocation &&
-    item?.geolocation?.latitude &&
-    item?.geolocation?.longitude &&
-    item?.geolocation?.latitude !== 0 &&
-    item?.geolocation?.longitude !== 0
-  );
+  if (item?.geolocation?.latitude !== 0 && item?.geolocation?.longitude !== 0) {
+    return (
+      item?.geolocation &&
+      item?.geolocation?.latitude &&
+      item?.geolocation?.longitude &&
+      item?.geolocation?.latitude !== 0 &&
+      item?.geolocation?.longitude !== 0
+    );
+  } 
 };

--- a/src/helpers/Item/item.js
+++ b/src/helpers/Item/item.js
@@ -37,12 +37,6 @@ export const getItemIcon = (item) => {
 
 export const hasGeolocation = (item) => {
   if (item?.geolocation?.latitude !== 0 && item?.geolocation?.longitude !== 0) {
-    return (
-      item?.geolocation &&
-      item?.geolocation?.latitude &&
-      item?.geolocation?.longitude &&
-      item?.geolocation?.latitude !== 0 &&
-      item?.geolocation?.longitude !== 0
-    );
+    return true;
   } 
 };


### PR DESCRIPTION
[US#75653](https://redturtle.tpondemand.com/RestUI/Board.aspx#page=profile&appConfig=eyJhY2lkIjoiM0YwMDA1MEY3Mzg3NjUxOEU4QTcxN0NGODgzMThEQUEifQ==&boardPopup=bug/75653/silent)

Handle no geolocation in person card. When creating or editing a person, if no geolocation is selected data for it is 
geolocation: {latitude: 0, longitude: 0} and in the person card is shown a 0 for the geolocation data.

Maybe is it possible to handle it in the BE? 