### PR TITLE
fix: bottoni categorie searchmap

### DIFF
--- a/src/components/Blocks/SearchMap/search-map.scss
+++ b/src/components/Blocks/SearchMap/search-map.scss
@@ -8,8 +8,8 @@
 
     .subjects {
       display: flex;
-      flex-wrap: wrap;
       overflow: scroll;
+      flex-wrap: wrap;
       button {
         flex: 0 0 auto;
       }

--- a/src/components/Blocks/SearchMap/search-map.scss
+++ b/src/components/Blocks/SearchMap/search-map.scss
@@ -8,6 +8,7 @@
 
     .subjects {
       display: flex;
+      flex-wrap: wrap;
       overflow: scroll;
       button {
         flex: 0 0 auto;


### PR DESCRIPTION
se le categorie sono molte ora fa così:

<img width="1482" height="116" alt="image" src="https://github.com/user-attachments/assets/c3028fc2-bd1e-4d57-b2f2-ee8b4c1ccbe6" />

con questa fix

<img width="1482" height="160" alt="image" src="https://github.com/user-attachments/assets/2050c7ae-d202-4f1c-bb2d-faca741e5aef" />
