### PR TITLE
feat: Search strutture - widget for type filter and description text for searchable text

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,12 @@
 - ...
  -->
 
+## Versione 2.33.0 (15/06/2026)
+
+### Migliorie
+
+- Nel blocco "Cerca strutture" è ora possibile scegliere se mostrare la ricerca libera (attiva di default) e se visualizzare il filtro per tipologia come pulsanti (comportamento attuale) oppure come menu a tendina.
+
 ## Versione 2.32.0 (12/06/2026)
 
 ### Migliorie

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,7 +45,7 @@
 
 ### Migliorie
 
-- Nel blocco "Cerca strutture" è ora possibile scegliere se mostrare la ricerca libera (attiva di default) e se visualizzare il filtro per tipologia come pulsanti (comportamento attuale) oppure come menu a tendina.
+- Nel blocco "Cerca strutture" è ora possibile personalizzare il testo descrittivo del campo di ricerca libero e se visualizzare il filtro per tipologia come pulsanti (comportamento di default) oppure come menu a tendina.
 
 ## Versione 2.32.0 (12/06/2026)
 

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -3207,7 +3207,7 @@ msgstr ""
 msgid "search_map_Show distretto"
 msgstr ""
 
-#. Default: "Mostra la barra di ricerca"
+#. Default: "Mostra la ricerca libera"
 #: components/Blocks/SearchMap/schema
 msgid "search_map_Show search bar"
 msgstr ""
@@ -3215,6 +3215,11 @@ msgstr ""
 #. Default: "Mostra i filtri per tipologia"
 #: components/Blocks/SearchMap/schema
 msgid "search_map_Show types"
+msgstr ""
+
+#. Default: "Tutte le tipologie"
+#: components/Blocks/SearchMap/Body
+msgid "search_map_all_tipologie"
 msgstr ""
 
 #. Default: "Ricerca con mappa"
@@ -3237,6 +3242,11 @@ msgstr "Municipality"
 msgid "search_map_label_distretto"
 msgstr "District"
 
+#. Default: "Tipologia"
+#: components/Blocks/SearchMap/Body
+msgid "search_map_label_tipologia"
+msgstr ""
+
 #. Default: "Cerca"
 #: components/Widgets/SearchBar/SearchBar
 msgid "search_map_searchable_text_button"
@@ -3257,9 +3267,19 @@ msgstr "Search for GPs and pediatricians near you"
 msgid "search_map_searchable_text_default_label_strutture"
 msgstr "Search for facilities near you"
 
+#. Default: "Testo descrittivo della barra di ricerca"
+#: components/Blocks/SearchMap/schema
+msgid "search_map_text_description"
+msgstr ""
+
 #. Default: "Titolo"
 #: components/Blocks/SearchMap/schema
 msgid "search_map_title"
+msgstr ""
+
+#. Default: "Filtra tipologia con menu a tendina"
+#: components/Blocks/SearchMap/schema
+msgid "search_map_types_as_select"
 msgstr ""
 
 #. Default: "Tutti i comuni"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -3207,7 +3207,7 @@ msgstr ""
 msgid "search_map_Show distretto"
 msgstr ""
 
-#. Default: "Mostra la barra di ricerca"
+#. Default: "Mostra la ricerca libera"
 #: components/Blocks/SearchMap/schema
 msgid "search_map_Show search bar"
 msgstr ""
@@ -3215,6 +3215,11 @@ msgstr ""
 #. Default: "Mostra i filtri per tipologia"
 #: components/Blocks/SearchMap/schema
 msgid "search_map_Show types"
+msgstr ""
+
+#. Default: "Tutte le tipologie"
+#: components/Blocks/SearchMap/Body
+msgid "search_map_all_tipologie"
 msgstr ""
 
 #. Default: "Ricerca con mappa"
@@ -3237,6 +3242,11 @@ msgstr ""
 msgid "search_map_label_distretto"
 msgstr ""
 
+#. Default: "Tipologia"
+#: components/Blocks/SearchMap/Body
+msgid "search_map_label_tipologia"
+msgstr ""
+
 #. Default: "Cerca"
 #: components/Widgets/SearchBar/SearchBar
 msgid "search_map_searchable_text_button"
@@ -3257,9 +3267,19 @@ msgstr ""
 msgid "search_map_searchable_text_default_label_strutture"
 msgstr ""
 
+#. Default: "Testo descrittivo della barra di ricerca"
+#: components/Blocks/SearchMap/schema
+msgid "search_map_text_description"
+msgstr ""
+
 #. Default: "Titolo"
 #: components/Blocks/SearchMap/schema
 msgid "search_map_title"
+msgstr ""
+
+#. Default: "Filtra tipologia con menu a tendina"
+#: components/Blocks/SearchMap/schema
+msgid "search_map_types_as_select"
 msgstr ""
 
 #. Default: "Tutti i comuni"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-06-12T14:38:11.948Z\n"
+"POT-Creation-Date: 2026-06-15T09:01:19.380Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -3209,7 +3209,7 @@ msgstr ""
 msgid "search_map_Show distretto"
 msgstr ""
 
-#. Default: "Mostra la barra di ricerca"
+#. Default: "Mostra la ricerca libera"
 #: components/Blocks/SearchMap/schema
 msgid "search_map_Show search bar"
 msgstr ""
@@ -3217,6 +3217,11 @@ msgstr ""
 #. Default: "Mostra i filtri per tipologia"
 #: components/Blocks/SearchMap/schema
 msgid "search_map_Show types"
+msgstr ""
+
+#. Default: "Tutte le tipologie"
+#: components/Blocks/SearchMap/Body
+msgid "search_map_all_tipologie"
 msgstr ""
 
 #. Default: "Ricerca con mappa"
@@ -3239,6 +3244,11 @@ msgstr ""
 msgid "search_map_label_distretto"
 msgstr ""
 
+#. Default: "Tipologia"
+#: components/Blocks/SearchMap/Body
+msgid "search_map_label_tipologia"
+msgstr ""
+
 #. Default: "Cerca"
 #: components/Widgets/SearchBar/SearchBar
 msgid "search_map_searchable_text_button"
@@ -3259,9 +3269,19 @@ msgstr ""
 msgid "search_map_searchable_text_default_label_strutture"
 msgstr ""
 
+#. Default: "Testo descrittivo della barra di ricerca"
+#: components/Blocks/SearchMap/schema
+msgid "search_map_text_description"
+msgstr ""
+
 #. Default: "Titolo"
 #: components/Blocks/SearchMap/schema
 msgid "search_map_title"
+msgstr ""
+
+#. Default: "Filtra tipologia con menu a tendina"
+#: components/Blocks/SearchMap/schema
+msgid "search_map_types_as_select"
 msgstr ""
 
 #. Default: "Tutti i comuni"

--- a/src/components/Blocks/SearchMap/Body.jsx
+++ b/src/components/Blocks/SearchMap/Body.jsx
@@ -422,9 +422,12 @@ const SearchMapBody = ({ data, id, path, properties, block, inEditMode }) => {
                       <SearchBar
                         id={block_id}
                         title={title}
-                        textDescription={intl.formatMessage(
-                          messages.searchable_text_decription,
-                        )}
+                        textDescription={
+                          data.text_description ||
+                          intl.formatMessage(
+                            messages.searchable_text_decription,
+                          )
+                        }
                         value={filters.searchableText}
                         onChange={(v) => {
                           setFilters({ ...filters, searchableText: v });

--- a/src/components/Blocks/SearchMap/Body.jsx
+++ b/src/components/Blocks/SearchMap/Body.jsx
@@ -86,6 +86,14 @@ const messages = defineMessages({
     id: 'search_map_label_distretto',
     defaultMessage: 'Distretto',
   },
+  label_tipologia: {
+    id: 'search_map_label_tipologia',
+    defaultMessage: 'Tipologia',
+  },
+  all_tipologie: {
+    id: 'search_map_all_tipologie',
+    defaultMessage: 'Tutte le tipologie',
+  },
 });
 
 const LeafIcon = (options, item) => {
@@ -503,46 +511,88 @@ const SearchMapBody = ({ data, id, path, properties, block, inEditMode }) => {
                 )}
 
                 {data.show_types && subjects.size > 0 && (
-                  <div className="subjects pb-3">
-                    {/*Chip 'tutti'*/}
-                    <Chip
-                      color="primary"
-                      simple
-                      tag={Button}
-                      onClick={() => {
-                        toggleSubject('_all_');
-                      }}
-                      className={cx({ active: filters.subjects.size === 0 })}
-                      aria-controls={results_region_id}
-                      aria-label={intl.formatMessage(
-                        messages.remove_all_subjects,
-                      )}
-                    >
-                      <ChipLabel>
-                        {intl.formatMessage(messages.all_subjects)}
-                      </ChipLabel>
-                    </Chip>
+                  <>
+                    {data.types_as_select ? (
+                      <Row className="pb-3 g-2">
+                        <Col xs="auto">
+                          <label
+                            htmlFor={block_id + '-tipologia-select'}
+                            className="form-label"
+                          >
+                            {intl.formatMessage(messages.label_tipologia)}
+                          </label>
+                          <select
+                            id={block_id + '-tipologia-select'}
+                            className="form-select"
+                            value={[...filters.subjects][0] ?? ''}
+                            aria-controls={results_region_id}
+                            onChange={(e) =>
+                              setFilters({
+                                ...filters,
+                                subjects: e.target.value
+                                  ? new Set([e.target.value])
+                                  : new Set(),
+                              })
+                            }
+                          >
+                            <option value="">
+                              {intl.formatMessage(messages.all_tipologie)}
+                            </option>
+                            {[...subjects].sort().map((s) => (
+                              <option key={s} value={s}>
+                                {s}
+                              </option>
+                            ))}
+                          </select>
+                        </Col>
+                      </Row>
+                    ) : (
+                      <div className="subjects pb-3">
+                        {/*Chip 'tutti'*/}
+                        <Chip
+                          color="primary"
+                          simple
+                          tag={Button}
+                          onClick={() => {
+                            toggleSubject('_all_');
+                          }}
+                          className={cx({
+                            active: filters.subjects.size === 0,
+                          })}
+                          aria-controls={results_region_id}
+                          aria-label={intl.formatMessage(
+                            messages.remove_all_subjects,
+                          )}
+                        >
+                          <ChipLabel>
+                            {intl.formatMessage(messages.all_subjects)}
+                          </ChipLabel>
+                        </Chip>
 
-                    {/*Chip delle varie categorie*/}
-                    {[...subjects].map((s) => (
-                      <Chip
-                        color="primary"
-                        simple
-                        tag={Button}
-                        key={s}
-                        onClick={() => {
-                          toggleSubject(s);
-                        }}
-                        className={cx({ active: filters.subjects.has(s) })}
-                        aria-label={
-                          intl.formatMessage(messages.filter_by) + ' ' + s
-                        }
-                        aria-controls={results_region_id}
-                      >
-                        <ChipLabel>{s}</ChipLabel>
-                      </Chip>
-                    ))}
-                  </div>
+                        {/*Chip delle varie categorie*/}
+                        {[...subjects].map((s) => (
+                          <Chip
+                            color="primary"
+                            simple
+                            tag={Button}
+                            key={s}
+                            onClick={() => {
+                              toggleSubject(s);
+                            }}
+                            className={cx({
+                              active: filters.subjects.has(s),
+                            })}
+                            aria-label={
+                              intl.formatMessage(messages.filter_by) + ' ' + s
+                            }
+                            aria-controls={results_region_id}
+                          >
+                            <ChipLabel>{s}</ChipLabel>
+                          </Chip>
+                        ))}
+                      </div>
+                    )}
+                  </>
                 )}
               </div>
 

--- a/src/components/Blocks/SearchMap/schema.js
+++ b/src/components/Blocks/SearchMap/schema.js
@@ -11,7 +11,7 @@ const messages = defineMessages({
   },
   show_search_bar: {
     id: 'search_map_Show search bar',
-    defaultMessage: 'Mostra la barra di ricerca',
+    defaultMessage: 'Mostra la ricerca libera',
   },
   text_description: {
     id: 'search_map_text_description',
@@ -20,6 +20,10 @@ const messages = defineMessages({
   show_types: {
     id: 'search_map_Show types',
     defaultMessage: 'Mostra i filtri per tipologia',
+  },
+  types_as_select: {
+    id: 'search_map_types_as_select',
+    defaultMessage: 'Filtra tipologia con menu a tendina',
   },
   show_city: {
     id: 'search_map_Show city',
@@ -53,7 +57,12 @@ export function SearchMapSchema({ formData, intl }) {
           'show_search_bar',
           ...(formData.show_search_bar ? ['text_description'] : []),
           ...(formData.portal_type === 'Struttura'
-            ? ['show_types', 'show_city', 'show_distretto']
+            ? [
+                'show_types',
+                ...(formData.show_types ? ['types_as_select'] : []),
+                'show_city',
+                'show_distretto',
+              ]
             : []),
         ],
       },
@@ -88,6 +97,11 @@ export function SearchMapSchema({ formData, intl }) {
       show_types: {
         title: intl.formatMessage(messages.show_types),
         type: 'boolean',
+      },
+      types_as_select: {
+        title: intl.formatMessage(messages.types_as_select),
+        type: 'boolean',
+        default: false,
       },
       show_city: {
         title: intl.formatMessage(messages.show_city),

--- a/src/components/Blocks/SearchMap/schema.js
+++ b/src/components/Blocks/SearchMap/schema.js
@@ -13,6 +13,10 @@ const messages = defineMessages({
     id: 'search_map_Show search bar',
     defaultMessage: 'Mostra la barra di ricerca',
   },
+  text_description: {
+    id: 'search_map_text_description',
+    defaultMessage: 'Testo descrittivo della barra di ricerca',
+  },
   show_types: {
     id: 'search_map_Show types',
     defaultMessage: 'Mostra i filtri per tipologia',
@@ -47,6 +51,7 @@ export function SearchMapSchema({ formData, intl }) {
           'path',
           'portal_type',
           'show_search_bar',
+          ...(formData.show_search_bar ? ['text_description'] : []),
           ...(formData.portal_type === 'Struttura'
             ? ['show_types', 'show_city', 'show_distretto']
             : []),
@@ -76,6 +81,9 @@ export function SearchMapSchema({ formData, intl }) {
         title: intl.formatMessage(messages.show_search_bar),
         type: 'boolean',
         default: true,
+      },
+      text_description: {
+        title: intl.formatMessage(messages.text_description),
       },
       show_types: {
         title: intl.formatMessage(messages.show_types),


### PR DESCRIPTION
Nel blocco "Cerca strutture" è ora possibile scegliere se mostrare la ricerca libera (attiva di default) e se visualizzare il filtro per tipologia come pulsanti (comportamento attuale) oppure come menu a tendina.