### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/themes.yml
+++ b/.github/workflows/themes.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [released]
 
+permissions: {}
+
 jobs:
   update:
     name: Update themes


### PR DESCRIPTION
Potential fix for [https://github.com/RedTurtle/io-sanita-theme/security/code-scanning/1](https://github.com/RedTurtle/io-sanita-theme/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/themes.yml` at the workflow root so it applies to all jobs unless overridden.  
Best minimal fix without changing behavior: set `permissions: {}` (no permissions) since this workflow does not need `GITHUB_TOKEN` access for checkout, commenting, releases, or repo writes. The job uses shell + `curl` with separate secrets, so disabling token permissions should preserve functionality while enforcing least privilege.

Edit region: directly after the `on:` trigger block and before `jobs:`.

No imports, methods, or dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
