### PR TITLE
Blocco Listing - template a tabella - corretto errore di rendering per campi con valori multipli ("Destinatari")

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- Blocco Listing con template a tabella. Corretta la visualizzazione dei campi con valori multipli (es. "Destinatari") che causavano un errore di rendering. I valori vengono ora mostrati correttamente come etichette separate da virgola.
+
 ## Versione 2.32.0 (12/06/2026)
 
 ### Migliorie

--- a/src/components/Blocks/Listing/Table/TableTemplate.jsx
+++ b/src/components/Blocks/Listing/Table/TableTemplate.jsx
@@ -86,7 +86,10 @@ const TableTemplate = (props) => {
                     c.field_properties ??
                     ct_schema?.[c.ct]?.result?.properties?.[c.field] ??
                     {};
-                  let render_value = JSON.stringify(item[c.field]);
+                  const raw = item[c.field];
+                  let render_value = Array.isArray(raw)
+                    ? raw.map((v) => v?.title ?? v).join(', ')
+                    : raw?.title ?? JSON.stringify(raw);
 
                   if (field_properties) {
                     const field = {

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -119,8 +119,6 @@ const Search = () => {
   const searchFilters = useSelector((state) => state.searchFilters.result);
   const searchResults = useSelector((state) => state.searchResults);
   const [sections, setSections] = useState([]);
-  console.log(qs.parse(location.search)?.sort_order);
-
   const [filters, setFilters] = useState({
     searchableText: qs.parse(location.search)?.SearchableText ?? '',
     parliamo_di: [],

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -119,6 +119,7 @@ const Search = () => {
   const searchFilters = useSelector((state) => state.searchFilters.result);
   const searchResults = useSelector((state) => state.searchResults);
   const [sections, setSections] = useState([]);
+
   const [filters, setFilters] = useState({
     searchableText: qs.parse(location.search)?.SearchableText ?? '',
     parliamo_di: [],

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -119,6 +119,7 @@ const Search = () => {
   const searchFilters = useSelector((state) => state.searchFilters.result);
   const searchResults = useSelector((state) => state.searchResults);
   const [sections, setSections] = useState([]);
+  console.log(qs.parse(location.search)?.sort_order);
 
   const [filters, setFilters] = useState({
     searchableText: qs.parse(location.search)?.SearchableText ?? '',


### PR DESCRIPTION
Il template a tabella del blocco Listing causava un errore di rendering in modalità visualizzazione (utenti anonimi e non in modifica) quando una colonna conteneva un campo con valori multipli (array di oggetti come il campo "Destinatari"). In assenza dello schema del tipo di contenuto, il valore veniva passato direttamente al widget di default causando un crash.

Fix: quando lo schema non è disponibile, i campi array vengono resi come lista di etichette separate da virgola. I campi oggetto con proprietà title vengono visualizzati correttamente.

Port of https://github.com/RedTurtle/design-comuni-plone-theme/pull/1123