### PR TITLE
76479 - Blocco elenco a tabella: salva lo schema del campo nelle colonne

### DIFF
--- a/src/components/Blocks/Listing/Table/TableTemplate.jsx
+++ b/src/components/Blocks/Listing/Table/TableTemplate.jsx
@@ -103,7 +103,8 @@ const TableTemplate = (props) => {
                       behavior: field_properties.behavior,
                     };
                     if (field_properties.widget === 'datetime') {
-                      widget_props.format = 'DD/MM/yyyy HH:MM';
+                      // HH:mm -> minutes (HH:MM would render the month)
+                      widget_props.format = 'DD/MM/yyyy HH:mm';
                     }
                     // per questi campi si è deciso dii non pubblicare ora:minuti
                     switch (c.field) {

--- a/src/components/Blocks/Listing/Table/TableTemplate.jsx
+++ b/src/components/Blocks/Listing/Table/TableTemplate.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { useIntl, defineMessages } from 'react-intl';
-import { Row, Col, Table } from 'design-react-kit';
+import { Table } from 'design-react-kit';
 import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
 import { useSelector } from 'react-redux';
 

--- a/src/components/manage/Widgets/CTFieldPropertiesWidget/CTFieldPropertiesWidget.jsx
+++ b/src/components/manage/Widgets/CTFieldPropertiesWidget/CTFieldPropertiesWidget.jsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import isEqual from 'lodash/isEqual';
+
+const CTFieldPropertiesWidget = (props) => {
+  const { onChange, id, value, objectvalue } = props;
+  const { ct, field } = objectvalue ?? {};
+  const ct_schema = useSelector(
+    (state) => state.ct_schema?.subrequests?.[ct]?.result,
+  );
+
+  useEffect(() => {
+    const field_properties = ct_schema?.properties?.[field];
+    if (field_properties && !isEqual(field_properties, value)) {
+      onChange(id, field_properties);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [objectvalue?.title, ct_schema]);
+
+  return null;
+};
+
+export default CTFieldPropertiesWidget;

--- a/src/config/blocks/listing/ListingOptions/tableTemplate.js
+++ b/src/config/blocks/listing/ListingOptions/tableTemplate.js
@@ -63,6 +63,10 @@ const ColumnSchema = ({ intl }) => ({
       description: intl.formatMessage(messages.title_description),
       widget: 'ct_title_column',
     },
+    field_properties: {
+      title: ' ',
+      widget: 'ct_field_properties',
+    },
     // sortable: {
     //   title: intl.formatMessage(messages.sortable),
     //   type: 'boolean',
@@ -109,7 +113,11 @@ export const addTableTemplateOptions = (
       schemaExtender: (schema, data, intl) => {
         const mutated = cloneDeep(schema);
         if (data.ct) {
-          mutated.fieldsets[0].fields.push('field', 'title' /*, 'sortable'*/);
+          mutated.fieldsets[0].fields.push(
+            'field',
+            'title',
+            'field_properties' /*, 'sortable'*/,
+          );
           mutated.properties.field.ct = data.ct;
         }
         return mutated;

--- a/src/config/widgets/widgets.js
+++ b/src/config/widgets/widgets.js
@@ -12,6 +12,11 @@ const CTTitleColumnWidget = loadable(() =>
     /* webpackChunkName: "ISManage" */ 'io-sanita-theme/components/manage/Widgets/CTTitleColumnWidget/CTTitleColumnWidget'
   ),
 );
+const CTFieldPropertiesWidget = loadable(() =>
+  import(
+    /* webpackChunkName: "ISManage" */ 'io-sanita-theme/components/manage/Widgets/CTFieldPropertiesWidget/CTFieldPropertiesWidget'
+  ),
+);
 const QuickSearchConfigurationWidget = loadable(() =>
   import(
     /* webpackChunkName: "ISManage" */ 'io-sanita-theme/components/manage/Widgets/QuickSearch/QuickSearchConfigurationWidget'
@@ -99,6 +104,7 @@ const getIoSanitaWidgets = (config) => {
       linkTo: LinkToWidget,
       ct_fields: CTFieldsWidget,
       ct_title_column: CTTitleColumnWidget,
+      ct_field_properties: CTFieldPropertiesWidget,
     },
     views: {
       ...config.widgets.views,


### PR DESCRIPTION
In the table variation of the list block, columns were not rendering correctly in anonymous view: the @types endpoint (used to determine the type/widget of each field) is only available in edit mode, while in anonymous context it returns Unauthorized. Without that information, the column has no way to know whether a field is date, datetime, etc.

As agreed in the discussion (cc @cekk), field schema information (type, widget, behavior, ...) is now saved inside each column at block save time. This way the view has everything it needs to render each column correctly, even in anonymous context, without additional backend calls.

**Changes**
New hidden widget CTFieldPropertiesWidget, in edit mode it reads the selected field's schema and persists it in the column as field_properties.
Widget registration (ct_field_properties).
Column schema, added the field_properties field.
TableTemplate, fixed datetime format (HH:MM → HH:mm: previously showed the month instead of minutes).
