### PR TITLE
Search farmacie3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,11 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+- Nel blocco di ricerca delle farmacie la colonna 'Periodi di Turno' è stata rinominata in 'Periodo e tipologia di turno'
+
 ## Versione 2.33.1 (01/07/2026)
 
 ### Fix

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,6 +47,8 @@
 
 - Nel blocco di ricerca delle farmacie possibilità di visualizzare solo i turni relativi alla data scelta
 - Nel blocco di ricerca delle farmacie la colonna 'Periodi di Turno' è stata rinominata in 'Periodo e tipologia di turno'
+- Nel blocco di ricerca delle farmacie è ora possibile scegliere dalle impostazioni del blocco se mostrare il CAP e la provincia nell'indirizzo dei risultati
+- Nella tabella dei risultati del blocco di ricerca delle farmacie la colonna 'Recapiti' è stata rinominata in 'Telefono'
 
 ## Versione 2.33.1 (01/07/2026)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,6 +44,8 @@
 ## Versione X.X.X (dd/mm/yyyy)
 
 ### Migliorie
+
+- Nel blocco di ricerca delle farmacie possibilità di visualizzare solo i turni relativi alla data scelta
 - Nel blocco di ricerca delle farmacie la colonna 'Periodi di Turno' è stata rinominata in 'Periodo e tipologia di turno'
 
 ## Versione 2.33.1 (01/07/2026)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,6 +49,7 @@
 - Nel blocco di ricerca delle farmacie la colonna 'Periodi di Turno' è stata rinominata in 'Periodo e tipologia di turno'
 - Nel blocco di ricerca delle farmacie è ora possibile scegliere dalle impostazioni del blocco se mostrare il CAP e la provincia nell'indirizzo dei risultati
 - Nella tabella dei risultati del blocco di ricerca delle farmacie la colonna 'Recapiti' è stata rinominata in 'Telefono'
+- Nel blocco di ricerca delle farmacie è ora possibile scegliere dalle impostazioni del blocco di visualizzare una mappa con la posizione delle farmacie trovate
 
 ## Versione 2.33.1 (01/07/2026)
 

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -3157,7 +3157,7 @@ msgstr "Contact numbers"
 msgid "search_farmacia_table_recapiti_en"
 msgstr ""
 
-#. Default: "Periodi di Turno"
+#. Default: "Periodo e tipologia di turno"
 #: components/Blocks/SearchFarmacia/Results
 msgid "search_farmacia_table_turni"
 msgstr "Shifts periods"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -3157,7 +3157,7 @@ msgstr ""
 msgid "search_farmacia_table_recapiti_en"
 msgstr ""
 
-#. Default: "Periodi di Turno"
+#. Default: "Periodo e tipologia di turno"
 #: components/Blocks/SearchFarmacia/Results
 msgid "search_farmacia_table_turni"
 msgstr ""

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -3159,7 +3159,7 @@ msgstr ""
 msgid "search_farmacia_table_recapiti_en"
 msgstr ""
 
-#. Default: "Periodi di Turno"
+#. Default: "Periodo e tipologia di turno"
 #: components/Blocks/SearchFarmacia/Results
 msgid "search_farmacia_table_turni"
 msgstr ""

--- a/src/components/Blocks/SearchFarmacia/Body.jsx
+++ b/src/components/Blocks/SearchFarmacia/Body.jsx
@@ -1,4 +1,4 @@
-import { createRef, useEffect, useState } from 'react';
+import { createRef, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { defineMessages, useIntl } from 'react-intl';
 import config from '@plone/volto/registry';
@@ -9,10 +9,12 @@ import {
   LinkedHeadline,
 } from 'io-sanita-theme/components';
 import { Container, Col, Row, Spinner } from 'design-react-kit';
+import { OSMMap } from 'volto-venue';
 import Results from './Results';
 import SearchFilters from './SearchFilters';
 import { isDateWithinTurno } from './turniUtils';
 import { getComuniOptions, filterFarmacieByComune } from './comuniUtils';
+import { getFarmacieMarkers } from './mapUtils';
 
 /* Style */
 import './search-farmacia.scss';
@@ -59,6 +61,7 @@ const Body = ({ isEditMode, data, id }) => {
   const showCap = data.show_cap ?? true;
   const showProvincia = data.show_provincia ?? true;
   const showLocalitaColonna = data.show_localita_colonna ?? true;
+  const showMap = data.show_map ?? false;
   const b_size = 10; // number of page results to show
   const [currentPage, setCurrentPage] = useState(0);
   const [filters, setFilters] = useState({
@@ -208,6 +211,12 @@ const Body = ({ isEditMode, data, id }) => {
     }
   }, [currentPage, results]);
 
+  // tutte le farmacie trovate hanno un pin sulla mappa, anche quelle non nella pagina corrente
+  const markers = useMemo(
+    () => (showMap ? getFarmacieMarkers(results, intl) : []),
+    [showMap, results, intl],
+  );
+
   const resultsWrapperId = 'search-farmacie-results_' + id;
   return (
     <div className="block iosanita-block-search farmacia">
@@ -286,6 +295,18 @@ const Body = ({ isEditMode, data, id }) => {
                 </Col>
               </Row>
             </form>
+
+            {showMap && markers.length > 0 && (
+              <div className="farmacie-map mb-4">
+                <OSMMap
+                  markers={markers}
+                  cluster={true}
+                  showTooltip={true}
+                  showPopup={true}
+                  mapOptions={{ scrollWheelZoom: false }}
+                />
+              </div>
+            )}
 
             <div
               className="farmacie-results shadow"

--- a/src/components/Blocks/SearchFarmacia/Body.jsx
+++ b/src/components/Blocks/SearchFarmacia/Body.jsx
@@ -58,6 +58,7 @@ const Body = ({ isEditMode, data, id }) => {
   const showLocalita = data.show_localita ?? searchType === 'vacations';
   const showCap = data.show_cap ?? true;
   const showProvincia = data.show_provincia ?? true;
+  const showLocalitaColonna = data.show_localita_colonna ?? true;
   const b_size = 10; // number of page results to show
   const [currentPage, setCurrentPage] = useState(0);
   const [filters, setFilters] = useState({
@@ -302,6 +303,7 @@ const Body = ({ isEditMode, data, id }) => {
                 searchDate={filters.date}
                 showCap={showCap}
                 showProvincia={showProvincia}
+                showLocalitaColonna={showLocalitaColonna}
               />
               {results && results.length > b_size && (
                 <Pagination

--- a/src/components/Blocks/SearchFarmacia/Body.jsx
+++ b/src/components/Blocks/SearchFarmacia/Body.jsx
@@ -56,6 +56,8 @@ const Body = ({ isEditMode, data, id }) => {
     data.show_area_territoriale ?? searchType !== 'vacations';
   const showComune = data.show_comune ?? searchType === 'vacations';
   const showLocalita = data.show_localita ?? searchType === 'vacations';
+  const showCap = data.show_cap ?? true;
+  const showProvincia = data.show_provincia ?? true;
   const b_size = 10; // number of page results to show
   const [currentPage, setCurrentPage] = useState(0);
   const [filters, setFilters] = useState({
@@ -298,6 +300,8 @@ const Body = ({ isEditMode, data, id }) => {
                 searchType={searchType}
                 onlyActiveTurno={data?.only_active_turno}
                 searchDate={filters.date}
+                showCap={showCap}
+                showProvincia={showProvincia}
               />
               {results && results.length > b_size && (
                 <Pagination

--- a/src/components/Blocks/SearchFarmacia/Body.jsx
+++ b/src/components/Blocks/SearchFarmacia/Body.jsx
@@ -11,6 +11,8 @@ import {
 import { Container, Col, Row, Spinner } from 'design-react-kit';
 import Results from './Results';
 import SearchFilters from './SearchFilters';
+import { isDateWithinTurno } from './turniUtils';
+import { getComuniOptions, filterFarmacieByComune } from './comuniUtils';
 
 /* Style */
 import './search-farmacia.scss';
@@ -92,17 +94,10 @@ const Body = ({ isEditMode, data, id }) => {
   useEffect(() => {
     if (searchFarmacia?.items) {
       setFiltersOptions({
-        comuni: [
-          ...new Set(searchFarmacia.items.map((item) => item.comune).sort()),
-        ].map((item) => {
-          return { value: item, label: item };
-        }),
+        comuni: getComuniOptions(searchFarmacia.items),
         localita: [
           ...new Set(
-            searchFarmacia.items
-              .filter(
-                (item) => !filters.comune || item.comune === filters.comune,
-              )
+            filterFarmacieByComune(searchFarmacia.items, filters.comune)
               .map((item) => item.localita)
               .sort(),
           ),
@@ -133,25 +128,9 @@ const Body = ({ isEditMode, data, id }) => {
     if (searchType === 'shifts' && filters.date && items?.length > 0) {
       const inputDate = new Date(filters.date).getTime();
 
-      newResults = newResults.filter((item) => {
-        const checkTurno = item?.turni?.map((turno) => {
-          const dalSplit = turno?.dal.split('/');
-          const alSplit = turno?.al.split('/');
-          const turnoDal = new Date(
-            +dalSplit[2],
-            dalSplit[1] - 1,
-            +dalSplit[0],
-          ).getTime();
-          const turnoAl = new Date(
-            +alSplit[2],
-            alSplit[1] - 1,
-            +alSplit[0],
-          ).getTime();
-
-          return turnoDal <= inputDate && turnoAl >= inputDate ? true : false;
-        });
-        return checkTurno && checkTurno.includes(true);
-      });
+      newResults = newResults.filter((item) =>
+        item?.turni?.some((turno) => isDateWithinTurno(turno, inputDate)),
+      );
     }
 
     // Turni - filtro Area Territoriale
@@ -163,11 +142,7 @@ const Body = ({ isEditMode, data, id }) => {
 
     // Ferie - filtro Comune
     if (filters.comune && filters.comune !== null) {
-      newResults = newResults.filter(
-        (item) =>
-          item.comune &&
-          item.comune.toLowerCase() === filters.comune.toLowerCase(),
-      );
+      newResults = filterFarmacieByComune(newResults, filters.comune);
     }
 
     // Ferie - filtro Località
@@ -321,6 +296,8 @@ const Body = ({ isEditMode, data, id }) => {
                 items={resultsPage}
                 isEditMode={isEditMode}
                 searchType={searchType}
+                onlyActiveTurno={data?.only_active_turno}
+                searchDate={filters.date}
               />
               {results && results.length > b_size && (
                 <Pagination

--- a/src/components/Blocks/SearchFarmacia/Results.jsx
+++ b/src/components/Blocks/SearchFarmacia/Results.jsx
@@ -46,7 +46,7 @@ const messages = defineMessages({
   },
   turni: {
     id: 'search_farmacia_table_turni',
-    defaultMessage: 'Periodi di Turno',
+    defaultMessage: 'Periodo e tipologia di turno',
   },
   turni_en: {
     id: 'search_farmacia_table_turni_en',
@@ -250,7 +250,7 @@ const Results = ({ items, isEditMode, searchType }) => {
                   searchType={searchType}
                 />
 
-                {/* Periodi di turno */}
+                {/* Periodo e tipologia di turno */}
                 {searchType !== 'vacations' && (
                   <td className="turni">
                     <div className="th d-lg-none">

--- a/src/components/Blocks/SearchFarmacia/Results.jsx
+++ b/src/components/Blocks/SearchFarmacia/Results.jsx
@@ -39,11 +39,11 @@ const messages = defineMessages({
   },
   recapiti: {
     id: 'search_farmacia_table_recapiti',
-    defaultMessage: 'Recapiti',
+    defaultMessage: 'Telefono',
   },
   recapiti_en: {
     id: 'search_farmacia_table_recapiti_en',
-    defaultMessage: 'Contact numbers',
+    defaultMessage: 'Phone number',
   },
   turni: {
     id: 'search_farmacia_table_turni',
@@ -69,22 +69,23 @@ const messages = defineMessages({
     id: 'search_farmacia_period_to',
     defaultMessage: 'al',
   },
-  telefono: {
-    id: 'search_farmacia_telefono',
-    defaultMessage: 'Telefono',
-  },
-  telefono_turno: {
-    id: 'search_farmacia_telefono_turno',
-    defaultMessage: 'Telefono turno',
-  },
   no_results: {
     id: 'search_farmacia_no_results',
     defaultMessage: 'Nessun risultato trovato',
   },
 });
 
-const ContactColumns = ({ isEditMode, item, searchType }) => {
+const ContactColumns = ({
+  isEditMode,
+  item,
+  searchType,
+  showCap,
+  showProvincia,
+}) => {
   const intl = useIntl();
+  const showZip = showCap && item?.zip_code;
+  const showProv = showProvincia && item?.provincia;
+  const hasSecondAddressLine = showZip || item?.localita || showProv;
 
   return (
     <>
@@ -115,14 +116,14 @@ const ContactColumns = ({ isEditMode, item, searchType }) => {
           {intl.formatMessage(messages.indirizzo_en)}
         </div>
 
-        {item?.street || item?.zip_code || item?.localita || item?.provincia ? (
+        {item?.street || hasSecondAddressLine ? (
           <p>
             {item?.street && item.street}
-            {item?.street && item?.zip_code && <br />}
-            {item?.zip_code && item.zip_code}
-            {item?.zip_code && item?.localita && <> </>}
+            {item?.street && hasSecondAddressLine && <br />}
+            {showZip && item.zip_code}
+            {showZip && item?.localita && <> </>}
             {item?.localita && item.localita}
-            {item?.provincia && <> ({item.provincia}) </>}
+            {showProv && <> ({item.provincia}) </>}
           </p>
         ) : (
           <> - </>
@@ -136,7 +137,6 @@ const ContactColumns = ({ isEditMode, item, searchType }) => {
         </div>
         {item.telefono && searchType === 'vacations' && (
           <p className="my-0">
-            {`${intl.formatMessage(messages.telefono)}: `}
             <PuntoDiContattoValue
               value={{ tipo: 'telefono', valore: item.telefono }}
             />
@@ -144,7 +144,6 @@ const ContactColumns = ({ isEditMode, item, searchType }) => {
         )}
         {item.telefono_turno && searchType !== 'vacations' && (
           <p className="my-0">
-            {`${intl.formatMessage(messages.telefono_turno)}: `}
             <PuntoDiContattoValue
               value={{ tipo: 'telefono', valore: item.telefono_turno }}
             />
@@ -186,6 +185,8 @@ const Results = ({
   searchType,
   onlyActiveTurno,
   searchDate,
+  showCap,
+  showProvincia,
 }) => {
   const intl = useIntl();
 
@@ -261,6 +262,8 @@ const Results = ({
                     isEditMode={isEditMode}
                     item={item}
                     searchType={searchType}
+                    showCap={showCap}
+                    showProvincia={showProvincia}
                   />
 
                   {/* Periodo e tipologia di turno */}

--- a/src/components/Blocks/SearchFarmacia/Results.jsx
+++ b/src/components/Blocks/SearchFarmacia/Results.jsx
@@ -2,6 +2,7 @@ import UniversalLink from '@plone/volto/components/manage/UniversalLink/Universa
 import { PuntoDiContattoValue } from 'io-sanita-theme/helpers';
 import { defineMessages, useIntl } from 'react-intl';
 import { Table } from 'semantic-ui-react';
+import { getActiveTurni } from './turniUtils';
 
 const messages = defineMessages({
   nome: {
@@ -179,7 +180,13 @@ const PeriodsStructure = ({ periods }) => {
   );
 };
 
-const Results = ({ items, isEditMode, searchType }) => {
+const Results = ({
+  items,
+  isEditMode,
+  searchType,
+  onlyActiveTurno,
+  searchDate,
+}) => {
   const intl = useIntl();
 
   return (
@@ -230,51 +237,58 @@ const Results = ({ items, isEditMode, searchType }) => {
             </Table.Row>
           </Table.Header>
           <tbody>
-            {items.map((item, i) => (
-              <tr key={i}>
-                <td className="nome">
-                  {item['@id'] && (
-                    <p>
-                      <UniversalLink
-                        item={!isEditMode ? item : null}
-                        href={isEditMode ? '#' : null}
-                      >
-                        {item.title}
-                      </UniversalLink>
-                    </p>
+            {items.map((item, i) => {
+              const turniDaMostrare =
+                onlyActiveTurno && searchDate
+                  ? getActiveTurni(item.turni, searchDate)
+                  : item.turni;
+
+              return (
+                <tr key={i}>
+                  <td className="nome">
+                    {item['@id'] && (
+                      <p>
+                        <UniversalLink
+                          item={!isEditMode ? item : null}
+                          href={isEditMode ? '#' : null}
+                        >
+                          {item.title}
+                        </UniversalLink>
+                      </p>
+                    )}
+                  </td>
+                  <ContactColumns
+                    isEditMode={isEditMode}
+                    item={item}
+                    searchType={searchType}
+                  />
+
+                  {/* Periodo e tipologia di turno */}
+                  {searchType !== 'vacations' && (
+                    <td className="turni">
+                      <div className="th d-lg-none">
+                        {intl.formatMessage(messages.turni)}
+                        <br />
+                        {intl.formatMessage(messages.turni_en)}
+                      </div>
+                      <PeriodsStructure periods={turniDaMostrare} />
+                    </td>
                   )}
-                </td>
-                <ContactColumns
-                  isEditMode={isEditMode}
-                  item={item}
-                  searchType={searchType}
-                />
 
-                {/* Periodo e tipologia di turno */}
-                {searchType !== 'vacations' && (
-                  <td className="turni">
-                    <div className="th d-lg-none">
-                      {intl.formatMessage(messages.turni)}
-                      <br />
-                      {intl.formatMessage(messages.turni_en)}
-                    </div>
-                    <PeriodsStructure periods={item.turni} />
-                  </td>
-                )}
-
-                {/* Periodi di ferie */}
-                {searchType === 'vacations' && (
-                  <td className="ferie">
-                    <div className="th d-lg-none">
-                      {intl.formatMessage(messages.ferie)}
-                      <br />
-                      {intl.formatMessage(messages.ferie_en)}
-                    </div>
-                    <PeriodsStructure periods={item.ferie} />
-                  </td>
-                )}
-              </tr>
-            ))}
+                  {/* Periodi di ferie */}
+                  {searchType === 'vacations' && (
+                    <td className="ferie">
+                      <div className="th d-lg-none">
+                        {intl.formatMessage(messages.ferie)}
+                        <br />
+                        {intl.formatMessage(messages.ferie_en)}
+                      </div>
+                      <PeriodsStructure periods={item.ferie} />
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
           </tbody>
         </Table>
       ) : (

--- a/src/components/Blocks/SearchFarmacia/Results.jsx
+++ b/src/components/Blocks/SearchFarmacia/Results.jsx
@@ -81,6 +81,7 @@ const ContactColumns = ({
   searchType,
   showCap,
   showProvincia,
+  showLocalitaColonna,
 }) => {
   const intl = useIntl();
   const showZip = showCap && item?.zip_code;
@@ -99,15 +100,17 @@ const ContactColumns = ({
         {item?.comune ? <p>{item.comune}</p> : <> - </>}
       </td>
 
-      <td className="localita">
-        <div className="th d-lg-none">
-          {intl.formatMessage(messages.localita)}
-          <br />
-          {intl.formatMessage(messages.localita_en)}
-        </div>
+      {showLocalitaColonna && (
+        <td className="localita">
+          <div className="th d-lg-none">
+            {intl.formatMessage(messages.localita)}
+            <br />
+            {intl.formatMessage(messages.localita_en)}
+          </div>
 
-        {item?.localita ? <p>{item.localita}</p> : <> - </>}
-      </td>
+          {item?.localita ? <p>{item.localita}</p> : <> - </>}
+        </td>
+      )}
 
       <td className="indirizzo">
         <div className="th d-lg-none">
@@ -187,6 +190,7 @@ const Results = ({
   searchDate,
   showCap,
   showProvincia,
+  showLocalitaColonna,
 }) => {
   const intl = useIntl();
 
@@ -204,11 +208,13 @@ const Results = ({
                 {intl.formatMessage(messages.comune)} <br />
                 {intl.formatMessage(messages.comune_en)}
               </Table.HeaderCell>
-              <Table.HeaderCell>
-                {intl.formatMessage(messages.localita)}
-                <br />
-                {intl.formatMessage(messages.localita_en)}
-              </Table.HeaderCell>
+              {showLocalitaColonna && (
+                <Table.HeaderCell>
+                  {intl.formatMessage(messages.localita)}
+                  <br />
+                  {intl.formatMessage(messages.localita_en)}
+                </Table.HeaderCell>
+              )}
               <Table.HeaderCell>
                 {intl.formatMessage(messages.indirizzo)}
                 <br />
@@ -264,6 +270,7 @@ const Results = ({
                     searchType={searchType}
                     showCap={showCap}
                     showProvincia={showProvincia}
+                    showLocalitaColonna={showLocalitaColonna}
                   />
 
                   {/* Periodo e tipologia di turno */}

--- a/src/components/Blocks/SearchFarmacia/SearchFilters.jsx
+++ b/src/components/Blocks/SearchFarmacia/SearchFilters.jsx
@@ -2,6 +2,7 @@ import { DatetimeWidget } from '@plone/volto/components/manage/Widgets';
 import { Row, Col } from 'design-react-kit';
 import { SearchBar, SelectInput } from 'io-sanita-theme/components';
 import { defineMessages, useIntl } from 'react-intl';
+import { getComuneSelectValue } from './comuniUtils';
 
 const messages = defineMessages({
   search_keyword: {
@@ -104,12 +105,7 @@ const SearchFilters = ({
         <Col lg="3" className="d-flex align-center">
           <SelectInput
             id="comune"
-            value={
-              filters['comune'] && {
-                value: filters['comune'],
-                label: filters['comune'],
-              }
-            }
+            value={getComuneSelectValue(filters.comune, options.comuni)}
             placeholder={intl.formatMessage(messages.comune)}
             onChange={(opt) => {
               setFilters({ ...filters, comune: opt?.value });

--- a/src/components/Blocks/SearchFarmacia/comuniUtils.js
+++ b/src/components/Blocks/SearchFarmacia/comuniUtils.js
@@ -1,0 +1,35 @@
+/**
+ * Options for the "Comune" select, built from the unique `comune` values
+ * present in the loaded farmacie.
+ */
+export const getComuniOptions = (items) =>
+  [...new Set((items ?? []).map((item) => item.comune).sort())].map(
+    (item) => ({ value: item, label: item }),
+  );
+
+/**
+ * Farmacie whose `comune` matches the given value (case-insensitive).
+ * Returns `items` unchanged when `comuneValue` is falsy.
+ */
+export const filterFarmacieByComune = (items, comuneValue) => {
+  if (!comuneValue) return items ?? [];
+  return (items ?? []).filter(
+    (item) =>
+      item.comune && item.comune.toLowerCase() === comuneValue.toLowerCase(),
+  );
+};
+
+/**
+ * Resolves the react-select value/label pair for the currently selected
+ * comune, looking it up in `comuniOptions` so that custom options (whose
+ * label differs from their value) are displayed correctly.
+ */
+export const getComuneSelectValue = (comuneValue, comuniOptions) => {
+  if (!comuneValue) return null;
+  return (
+    (comuniOptions ?? []).find((opt) => opt.value === comuneValue) ?? {
+      value: comuneValue,
+      label: comuneValue,
+    }
+  );
+};

--- a/src/components/Blocks/SearchFarmacia/comuniUtils.js
+++ b/src/components/Blocks/SearchFarmacia/comuniUtils.js
@@ -3,9 +3,10 @@
  * present in the loaded farmacie.
  */
 export const getComuniOptions = (items) =>
-  [...new Set((items ?? []).map((item) => item.comune).sort())].map(
-    (item) => ({ value: item, label: item }),
-  );
+  [...new Set((items ?? []).map((item) => item.comune).sort())].map((item) => ({
+    value: item,
+    label: item,
+  }));
 
 /**
  * Farmacie whose `comune` matches the given value (case-insensitive).

--- a/src/components/Blocks/SearchFarmacia/mapUtils.jsx
+++ b/src/components/Blocks/SearchFarmacia/mapUtils.jsx
@@ -1,0 +1,58 @@
+import ReactDOMServer from 'react-dom/server';
+import { mapPinDirections } from 'io-sanita-theme/helpers';
+import ioSanitaPin from 'io-sanita-theme/components/Blocks/SearchMap/map-pin.svg';
+
+const LeafIcon = (options, item) => {
+  return {
+    html: ReactDOMServer.renderToString(
+      <img
+        src={options.iconUrl}
+        alt={item.title}
+        width={options.iconSize[0]}
+        height={options.iconSize[1]}
+      />,
+    ),
+    ...options,
+  };
+};
+
+// i dati delle farmacie arrivano da @searchfarmacie con lat/lng piatte
+// (latitudine/longitudine) invece del campo geolocation annidato
+export const hasFarmaciaGeolocation = (item) => {
+  const lat = Number(item?.latitudine);
+  const lng = Number(item?.longitudine);
+  return !!item && !!lat && !!lng;
+};
+
+export const getFarmaciaMarker = (item, intl) => {
+  if (!hasFarmaciaGeolocation(item)) {
+    return null;
+  }
+  const latitude = Number(item.latitudine);
+  const longitude = Number(item.longitudine);
+  const point = {
+    ...item,
+    latitude,
+    longitude,
+    geolocation: { latitude, longitude },
+    city: item.comune,
+    province: item.provincia,
+  };
+
+  return {
+    ...point,
+    divIcon: LeafIcon(
+      {
+        iconUrl: ioSanitaPin,
+        iconSize: [25, 40],
+        iconAnchor: [12.5, 20],
+        className: '',
+      },
+      point,
+    ),
+    popupContent: mapPinDirections(point, intl),
+  };
+};
+
+export const getFarmacieMarkers = (items, intl) =>
+  (items ?? []).map((item) => getFarmaciaMarker(item, intl)).filter(Boolean);

--- a/src/components/Blocks/SearchFarmacia/schema.js
+++ b/src/components/Blocks/SearchFarmacia/schema.js
@@ -42,6 +42,10 @@ const messages = defineMessages({
     id: 'search_farmacia_show_localita_colonna',
     defaultMessage: 'Mostra la colonna Località nella tabella dei risultati',
   },
+  show_map: {
+    id: 'search_farmacia_show_map',
+    defaultMessage: 'Mostra la mappa con le farmacie trovate',
+  },
 });
 
 export function SearchFarmaciaSchema({ formData, intl }) {
@@ -61,6 +65,7 @@ export function SearchFarmaciaSchema({ formData, intl }) {
           'show_cap',
           'show_provincia',
           'show_localita_colonna',
+          'show_map',
         ],
       },
     ],
@@ -110,6 +115,11 @@ export function SearchFarmaciaSchema({ formData, intl }) {
         title: intl.formatMessage(messages.show_localita_colonna),
         type: 'boolean',
         default: true,
+      },
+      show_map: {
+        title: intl.formatMessage(messages.show_map),
+        type: 'boolean',
+        default: false,
       },
     },
     required: [],

--- a/src/components/Blocks/SearchFarmacia/schema.js
+++ b/src/components/Blocks/SearchFarmacia/schema.js
@@ -30,6 +30,14 @@ const messages = defineMessages({
     defaultMessage:
       'Mostra solo il turno del giorno selezionato (anziché tutti i periodi)',
   },
+  show_cap: {
+    id: 'search_farmacia_show_cap',
+    defaultMessage: 'Mostra il CAP nella tabella dei risultati',
+  },
+  show_provincia: {
+    id: 'search_farmacia_show_provincia',
+    defaultMessage: 'Mostra la provincia nella tabella dei risultati',
+  },
 });
 
 export function SearchFarmaciaSchema({ formData, intl }) {
@@ -46,6 +54,8 @@ export function SearchFarmaciaSchema({ formData, intl }) {
           'show_comune',
           'show_localita',
           'only_active_turno',
+          'show_cap',
+          'show_provincia',
         ],
       },
     ],
@@ -80,6 +90,16 @@ export function SearchFarmaciaSchema({ formData, intl }) {
         title: intl.formatMessage(messages.only_active_turno),
         type: 'boolean',
         default: false,
+      },
+      show_cap: {
+        title: intl.formatMessage(messages.show_cap),
+        type: 'boolean',
+        default: true,
+      },
+      show_provincia: {
+        title: intl.formatMessage(messages.show_provincia),
+        type: 'boolean',
+        default: true,
       },
     },
     required: [],

--- a/src/components/Blocks/SearchFarmacia/schema.js
+++ b/src/components/Blocks/SearchFarmacia/schema.js
@@ -38,6 +38,10 @@ const messages = defineMessages({
     id: 'search_farmacia_show_provincia',
     defaultMessage: 'Mostra la provincia nella tabella dei risultati',
   },
+  show_localita_colonna: {
+    id: 'search_farmacia_show_localita_colonna',
+    defaultMessage: 'Mostra la colonna Località nella tabella dei risultati',
+  },
 });
 
 export function SearchFarmaciaSchema({ formData, intl }) {
@@ -56,6 +60,7 @@ export function SearchFarmaciaSchema({ formData, intl }) {
           'only_active_turno',
           'show_cap',
           'show_provincia',
+          'show_localita_colonna',
         ],
       },
     ],
@@ -98,6 +103,11 @@ export function SearchFarmaciaSchema({ formData, intl }) {
       },
       show_provincia: {
         title: intl.formatMessage(messages.show_provincia),
+        type: 'boolean',
+        default: true,
+      },
+      show_localita_colonna: {
+        title: intl.formatMessage(messages.show_localita_colonna),
         type: 'boolean',
         default: true,
       },

--- a/src/components/Blocks/SearchFarmacia/schema.js
+++ b/src/components/Blocks/SearchFarmacia/schema.js
@@ -25,6 +25,11 @@ const messages = defineMessages({
     id: 'search_farmacia_show_localita',
     defaultMessage: 'Mostra il filtro per località',
   },
+  only_active_turno: {
+    id: 'search_farmacia_only_active_turno',
+    defaultMessage:
+      'Mostra solo il turno del giorno selezionato (anziché tutti i periodi)',
+  },
 });
 
 export function SearchFarmaciaSchema({ formData, intl }) {
@@ -40,6 +45,7 @@ export function SearchFarmaciaSchema({ formData, intl }) {
           'show_area_territoriale',
           'show_comune',
           'show_localita',
+          'only_active_turno',
         ],
       },
     ],
@@ -69,6 +75,11 @@ export function SearchFarmaciaSchema({ formData, intl }) {
         title: intl.formatMessage(messages.show_localita),
         type: 'boolean',
         default: formData?.search_type === 'vacations',
+      },
+      only_active_turno: {
+        title: intl.formatMessage(messages.only_active_turno),
+        type: 'boolean',
+        default: false,
       },
     },
     required: [],

--- a/src/components/Blocks/SearchFarmacia/search-farmacia.scss
+++ b/src/components/Blocks/SearchFarmacia/search-farmacia.scss
@@ -45,6 +45,11 @@
       }
     }
   }
+  .farmacie-map {
+    #geocoded-result {
+      height: 400px;
+    }
+  }
 }
 
 .cms-ui {

--- a/src/components/Blocks/SearchFarmacia/turniUtils.js
+++ b/src/components/Blocks/SearchFarmacia/turniUtils.js
@@ -2,22 +2,53 @@
  * Turno dal/al strings can be "DD/MM/YYYY" or "DD/MM/YYYY HH:MM" (the time
  * suffix is added when the xlsx import provides an hour range).
  */
-export const parseItDate = (value) => {
+export const parseItDate = (value, { endOfDay = false } = {}) => {
   if (!value) return null;
-  const datePart = value.split(' ')[0];
+  const [datePart, timePart] = value.split(' ');
   const [day, month, year] = datePart.split('/');
   if (!day || !month || !year) return null;
-  const timestamp = new Date(+year, +month - 1, +day).getTime();
+
+  let hours = 0;
+  let minutes = 0;
+  let seconds = 0;
+  let milliseconds = 0;
+  if (timePart) {
+    const [hh, mm] = timePart.split(':');
+    hours = +hh || 0;
+    minutes = +mm || 0;
+  } else if (endOfDay) {
+    hours = 23;
+    minutes = 59;
+    seconds = 59;
+    milliseconds = 999;
+  }
+
+  const timestamp = new Date(
+    +year,
+    +month - 1,
+    +day,
+    hours,
+    minutes,
+    seconds,
+    milliseconds,
+  ).getTime();
   return Number.isNaN(timestamp) ? null : timestamp;
 };
 
 export const isDateWithinTurno = (turno, targetDate) => {
-  const target = targetDate instanceof Date ? targetDate.getTime() : targetDate;
+  const target =
+    targetDate instanceof Date
+      ? targetDate.getTime()
+      : typeof targetDate === 'string'
+        ? new Date(targetDate).getTime()
+        : targetDate;
   const dal = parseItDate(turno?.dal);
-  const al = parseItDate(turno?.al);
+  const al = parseItDate(turno?.al, { endOfDay: true });
   if (dal === null || al === null || target == null) return false;
   return dal <= target && target <= al;
 };
 
-export const getActiveTurni = (turni, targetDate) =>
-  (turni ?? []).filter((turno) => isDateWithinTurno(turno, targetDate));
+export const getActiveTurni = (turni, targetDate) => {
+  
+  return (turni ?? []).filter((turno) => isDateWithinTurno(turno, targetDate));
+};

--- a/src/components/Blocks/SearchFarmacia/turniUtils.js
+++ b/src/components/Blocks/SearchFarmacia/turniUtils.js
@@ -8,29 +8,14 @@ export const parseItDate = (value, { endOfDay = false } = {}) => {
   const [day, month, year] = datePart.split('/');
   if (!day || !month || !year) return null;
 
-  let hours = 0;
-  let minutes = 0;
-  let seconds = 0;
-  let milliseconds = 0;
-  if (timePart) {
-    const [hh, mm] = timePart.split(':');
-    hours = +hh || 0;
-    minutes = +mm || 0;
-  } else if (endOfDay) {
-    hours = 23;
-    minutes = 59;
-    seconds = 59;
-    milliseconds = 999;
-  }
-
   const timestamp = new Date(
     +year,
     +month - 1,
     +day,
-    hours,
-    minutes,
-    seconds,
-    milliseconds,
+    timePart ? timePart.split(':')[0] : endOfDay ? 23 : 0,
+    timePart ? timePart.split(':')[1] : endOfDay ? 59 : 0,
+    endOfDay ? 59 : 0,
+    endOfDay ? 999 : 0,
   ).getTime();
   return Number.isNaN(timestamp) ? null : timestamp;
 };

--- a/src/components/Blocks/SearchFarmacia/turniUtils.js
+++ b/src/components/Blocks/SearchFarmacia/turniUtils.js
@@ -40,8 +40,8 @@ export const isDateWithinTurno = (turno, targetDate) => {
     targetDate instanceof Date
       ? targetDate.getTime()
       : typeof targetDate === 'string'
-        ? new Date(targetDate).getTime()
-        : targetDate;
+      ? new Date(targetDate).getTime()
+      : targetDate;
   const dal = parseItDate(turno?.dal);
   const al = parseItDate(turno?.al, { endOfDay: true });
   if (dal === null || al === null || target == null) return false;
@@ -49,6 +49,5 @@ export const isDateWithinTurno = (turno, targetDate) => {
 };
 
 export const getActiveTurni = (turni, targetDate) => {
-  
   return (turni ?? []).filter((turno) => isDateWithinTurno(turno, targetDate));
 };

--- a/src/components/Blocks/SearchFarmacia/turniUtils.js
+++ b/src/components/Blocks/SearchFarmacia/turniUtils.js
@@ -1,0 +1,23 @@
+/**
+ * Turno dal/al strings can be "DD/MM/YYYY" or "DD/MM/YYYY HH:MM" (the time
+ * suffix is added when the xlsx import provides an hour range).
+ */
+export const parseItDate = (value) => {
+  if (!value) return null;
+  const datePart = value.split(' ')[0];
+  const [day, month, year] = datePart.split('/');
+  if (!day || !month || !year) return null;
+  const timestamp = new Date(+year, +month - 1, +day).getTime();
+  return Number.isNaN(timestamp) ? null : timestamp;
+};
+
+export const isDateWithinTurno = (turno, targetDate) => {
+  const target = targetDate instanceof Date ? targetDate.getTime() : targetDate;
+  const dal = parseItDate(turno?.dal);
+  const al = parseItDate(turno?.al);
+  if (dal === null || al === null || target == null) return false;
+  return dal <= target && target <= al;
+};
+
+export const getActiveTurni = (turni, targetDate) =>
+  (turni ?? []).filter((turno) => isDateWithinTurno(turno, targetDate));

--- a/src/components/Blocks/SearchFarmacia/turniUtils.test.js
+++ b/src/components/Blocks/SearchFarmacia/turniUtils.test.js
@@ -1,0 +1,94 @@
+import { parseItDate, isDateWithinTurno, getActiveTurni } from './turniUtils';
+
+describe('parseItDate', () => {
+  it('returns null for empty/falsy input', () => {
+    expect(parseItDate(null)).toBeNull();
+    expect(parseItDate(undefined)).toBeNull();
+    expect(parseItDate('')).toBeNull();
+  });
+
+  it('parses a date-only string (DD/MM/YYYY)', () => {
+    expect(parseItDate('15/03/2024')).toBe(new Date(2024, 2, 15).getTime());
+  });
+
+  it('parses a date with a time suffix (DD/MM/YYYY HH:MM), ignoring the time', () => {
+    expect(parseItDate('15/03/2024 14:30')).toBe(
+      new Date(2024, 2, 15).getTime(),
+    );
+  });
+
+  it('returns null when the date part is incomplete', () => {
+    expect(parseItDate('15/03')).toBeNull();
+    expect(parseItDate('//2024')).toBeNull();
+  });
+
+  it('returns null for an invalid (non-numeric) date', () => {
+    expect(parseItDate('aa/bb/cccc')).toBeNull();
+  });
+});
+
+describe('isDateWithinTurno', () => {
+  const turno = { dal: '10/03/2024', al: '20/03/2024' };
+
+  it('returns true when the target date is within the range', () => {
+    expect(isDateWithinTurno(turno, new Date(2024, 2, 15).getTime())).toBe(
+      true,
+    );
+  });
+
+  it('returns true when the target date matches the boundaries', () => {
+    expect(isDateWithinTurno(turno, new Date(2024, 2, 10).getTime())).toBe(
+      true,
+    );
+    expect(isDateWithinTurno(turno, new Date(2024, 2, 20).getTime())).toBe(
+      true,
+    );
+  });
+
+  it('returns false when the target date is outside the range', () => {
+    expect(isDateWithinTurno(turno, new Date(2024, 2, 9).getTime())).toBe(
+      false,
+    );
+    expect(isDateWithinTurno(turno, new Date(2024, 2, 21).getTime())).toBe(
+      false,
+    );
+  });
+
+  it('accepts a Date instance as targetDate', () => {
+    expect(isDateWithinTurno(turno, new Date(2024, 2, 15))).toBe(true);
+  });
+
+  it('returns false when turno dates are missing/invalid', () => {
+    expect(isDateWithinTurno({ dal: null, al: '20/03/2024' }, Date.now())).toBe(
+      false,
+    );
+    expect(isDateWithinTurno({}, Date.now())).toBe(false);
+  });
+
+  it('returns false when targetDate is null/undefined', () => {
+    expect(isDateWithinTurno(turno, null)).toBe(false);
+    expect(isDateWithinTurno(turno, undefined)).toBe(false);
+  });
+});
+
+describe('getActiveTurni', () => {
+  const turni = [
+    { dal: '01/01/2024', al: '10/01/2024' },
+    { dal: '15/01/2024', al: '31/01/2024' },
+  ];
+
+  it('returns only the turni that include the target date', () => {
+    const target = new Date(2024, 0, 20).getTime();
+    expect(getActiveTurni(turni, target)).toEqual([turni[1]]);
+  });
+
+  it('returns an empty array when no turno matches', () => {
+    const target = new Date(2024, 1, 1).getTime();
+    expect(getActiveTurni(turni, target)).toEqual([]);
+  });
+
+  it('returns an empty array when turni is null/undefined', () => {
+    expect(getActiveTurni(null, Date.now())).toEqual([]);
+    expect(getActiveTurni(undefined, Date.now())).toEqual([]);
+  });
+});


### PR DESCRIPTION
- Filtro "solo turno attivo": nuova opzione only_active_turno in schema.js — se attiva e c'è una data selezionata, la tabella mostra solo i turni attivi in quella data invece di tutti i periodi (Results.jsx, Body.jsx).
- Refactoring logica turni: estratta in turniUtils.js (nuovo file) la logica di parsing date italiane (parseItDate, gestisce anche formati con orario) e di controllo appartenenza a un turno (isDateWithinTurno, getActiveTurni), sostituendo codice duplicato/inline in Body.jsx.
- Refactoring logica comuni: estratta in comuniUtils.js (nuovo file) la costruzione delle opzioni del select "Comune" (getComuniOptions), il filtro farmacie per comune (filterFarmacieByComune) e la risoluzione del valore selezionato nel select (getComuneSelectValue), usata anche in SearchFilters.jsx per mostrare correttamente la label quando il value non coincide. (nessuna modifica al comportamento attuale)
- Etichetta colonna turni rinominata da "Periodi di Turno" a "Periodo e tipologia di turno".
- Nuove opzioni schema show_cap, show_localita e show_provincia (default true) per mostrare/nascondere CAP, Localita e provincia nella colonna indirizzo dei risultati.
- Rimosse le etichette ridondanti "Telefono:" / "Telefono turno:" davanti ai numeri di telefono.
- Colonna "Recapiti" rinominata in "Telefono" (EN: "Contact numbers" → "Phone number").