### PR TITLE
fix: Fixed the height in the smallBlockLinksTemplate to 100% instead of 100px

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,20 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Migliorie
+
+- ...
+
+### Novità
+
+- ...
+
+### Fix
+
+- L'altezza delle immagini all'interno del blocco 'link solo immagini' è stata aumentata e non ha più un limite massimo. Ora tutte le card avranno la stessa altezza.
+
 ## Versione 2.34.0 (07/07/2026)
 
 ### Migliorie

--- a/src/components/Blocks/Listing/SmallBlockLinks/smallblockLinksTemplate.scss
+++ b/src/components/Blocks/Listing/SmallBlockLinks/smallblockLinksTemplate.scss
@@ -5,7 +5,7 @@
     position: relative;
     display: flex;
     overflow: hidden;
-    height: 100px;
+    height: 100%;
     align-items: center;
     justify-content: center;
     border: 8px solid $white;


### PR DESCRIPTION
height 100% set for better image visualization 

<img width="1466" height="483" alt="Screenshot 2026-07-09 at 09 24 06" src="https://github.com/user-attachments/assets/133df33d-9854-499e-9253-779cfc7069e7" />
