### PR TITLE
feat: mostra tipo turno in pagina farmacia e blocco Ricerca Farmacie

### DIFF
--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -3041,6 +3041,11 @@ msgstr ""
 msgid "search_farmacia_map_turni"
 msgstr ""
 
+#. Default: "Periodo di turno"
+#: components/Blocks/SearchFarmacia/mapUtils
+msgid "search_farmacia_map_turni_no_tipo"
+msgstr ""
+
 #. Default: "Vedi scheda della farmacia"
 #: components/Blocks/SearchFarmacia/mapUtils
 msgid "search_farmacia_map_view_details"
@@ -3230,6 +3235,16 @@ msgstr "Shift periods and type"
 #. Default: "Shift periods and type"
 #: components/Blocks/SearchFarmacia/Results
 msgid "search_farmacia_table_turni_en"
+msgstr ""
+
+#. Default: "Periodo di turno"
+#: components/Blocks/SearchFarmacia/Results
+msgid "search_farmacia_table_turni_no_tipo"
+msgstr "Shift period"
+
+#. Default: "Shift periods"
+#: components/Blocks/SearchFarmacia/Results
+msgid "search_farmacia_table_turni_no_tipo_en"
 msgstr ""
 
 #. Default: "Titolo"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -3132,6 +3132,11 @@ msgstr ""
 msgid "search_farmacia_show_map"
 msgstr ""
 
+#. Default: "Mostra il tipo di turno nella tabella dei risultati"
+#: components/Blocks/SearchFarmacia/schema
+msgid "search_farmacia_show_tipo_turno"
+msgstr ""
+
 #. Default: "Mostra il link al CSV open data con tutti i turni delle farmacie"
 #: components/Blocks/SearchFarmacia/schema
 msgid "search_farmacia_show_opendata_csv_link"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -1967,6 +1967,11 @@ msgstr "From"
 msgid "farmacia_turni_to"
 msgstr "To"
 
+#. Default: "Tipo turno"
+#: components/View/Farmacia/FarmaciaTurni
+msgid "farmacia_turni_tipo"
+msgstr "Shift type"
+
 #. Default: "Non ho avuto dubbi su quello che stavo facendo"
 #: overrideTranslations
 msgid "feedback_clear_proceeding"
@@ -3215,9 +3220,9 @@ msgstr ""
 #. Default: "Periodo e tipologia di turno"
 #: components/Blocks/SearchFarmacia/Results
 msgid "search_farmacia_table_turni"
-msgstr "Shifts periods"
+msgstr "Shift periods and type"
 
-#. Default: "Shifts periods"
+#. Default: "Shift periods and type"
 #: components/Blocks/SearchFarmacia/Results
 msgid "search_farmacia_table_turni_en"
 msgstr ""

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -3041,6 +3041,11 @@ msgstr ""
 msgid "search_farmacia_map_turni"
 msgstr ""
 
+#. Default: "Periodo di turno"
+#: components/Blocks/SearchFarmacia/mapUtils
+msgid "search_farmacia_map_turni_no_tipo"
+msgstr ""
+
 #. Default: "Vedi scheda della farmacia"
 #: components/Blocks/SearchFarmacia/mapUtils
 msgid "search_farmacia_map_view_details"
@@ -3230,6 +3235,16 @@ msgstr ""
 #. Default: "Shift periods and type"
 #: components/Blocks/SearchFarmacia/Results
 msgid "search_farmacia_table_turni_en"
+msgstr ""
+
+#. Default: "Periodo di turno"
+#: components/Blocks/SearchFarmacia/Results
+msgid "search_farmacia_table_turni_no_tipo"
+msgstr ""
+
+#. Default: "Shift periods"
+#: components/Blocks/SearchFarmacia/Results
+msgid "search_farmacia_table_turni_no_tipo_en"
 msgstr ""
 
 #. Default: "Titolo"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -3132,6 +3132,11 @@ msgstr ""
 msgid "search_farmacia_show_map"
 msgstr ""
 
+#. Default: "Mostra il tipo di turno nella tabella dei risultati"
+#: components/Blocks/SearchFarmacia/schema
+msgid "search_farmacia_show_tipo_turno"
+msgstr ""
+
 #. Default: "Mostra il link al CSV open data con tutti i turni delle farmacie"
 #: components/Blocks/SearchFarmacia/schema
 msgid "search_farmacia_show_opendata_csv_link"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1967,6 +1967,11 @@ msgstr ""
 msgid "farmacia_turni_to"
 msgstr ""
 
+#. Default: "Tipo turno"
+#: components/View/Farmacia/FarmaciaTurni
+msgid "farmacia_turni_tipo"
+msgstr ""
+
 #. Default: "Non ho avuto dubbi su quello che stavo facendo"
 #: overrideTranslations
 msgid "feedback_clear_proceeding"
@@ -3217,7 +3222,7 @@ msgstr ""
 msgid "search_farmacia_table_turni"
 msgstr ""
 
-#. Default: "Shifts periods"
+#. Default: "Shift periods and type"
 #: components/Blocks/SearchFarmacia/Results
 msgid "search_farmacia_table_turni_en"
 msgstr ""

--- a/src/components/Blocks/SearchFarmacia/Body.jsx
+++ b/src/components/Blocks/SearchFarmacia/Body.jsx
@@ -66,6 +66,7 @@ const Body = ({ isEditMode, data, id }) => {
   const showProvincia = data.show_provincia ?? true;
   const showLocalitaColonna = data.show_localita_colonna ?? true;
   const showMap = data.show_map ?? false;
+  const showTipoTurno = data.show_tipo_turno ?? false;
   const opendataCsvLinkEnabled =
     config.settings.siteProperties.enableFarmacieOpendataCsvLink ?? false;
   const showOpendataCsvLink =
@@ -226,6 +227,7 @@ const Body = ({ isEditMode, data, id }) => {
     showCap,
     showProvincia,
     showLocalitaColonna,
+    showTipoTurno,
     onlyActiveTurno: data?.only_active_turno,
     searchDate: filters.date,
   };
@@ -353,6 +355,7 @@ const Body = ({ isEditMode, data, id }) => {
                 showCap={showCap}
                 showProvincia={showProvincia}
                 showLocalitaColonna={showLocalitaColonna}
+                showTipoTurno={showTipoTurno}
               />
               {results && results.length > b_size && (
                 <Pagination

--- a/src/components/Blocks/SearchFarmacia/Results.jsx
+++ b/src/components/Blocks/SearchFarmacia/Results.jsx
@@ -53,6 +53,14 @@ const messages = defineMessages({
     id: 'search_farmacia_table_turni_en',
     defaultMessage: 'Shift periods and type',
   },
+  turni_no_tipo: {
+    id: 'search_farmacia_table_turni_no_tipo',
+    defaultMessage: 'Periodo di turno',
+  },
+  turni_no_tipo_en: {
+    id: 'search_farmacia_table_turni_no_tipo_en',
+    defaultMessage: 'Shift periods',
+  },
   ferie: {
     id: 'search_farmacia_table_ferie',
     defaultMessage: 'Periodi di Ferie',
@@ -234,9 +242,15 @@ const Results = ({
                 </>
               ) : (
                 <Table.HeaderCell>
-                  {intl.formatMessage(messages.turni)}
+                  {intl.formatMessage(
+                    showTipoTurno ? messages.turni : messages.turni_no_tipo,
+                  )}
                   <br />
-                  {intl.formatMessage(messages.turni_en)}
+                  {intl.formatMessage(
+                    showTipoTurno
+                      ? messages.turni_en
+                      : messages.turni_no_tipo_en,
+                  )}
                 </Table.HeaderCell>
               )}
             </Table.Row>
@@ -275,9 +289,17 @@ const Results = ({
                   {searchType !== 'vacations' && (
                     <td className="turni">
                       <div className="th d-lg-none">
-                        {intl.formatMessage(messages.turni)}
+                        {intl.formatMessage(
+                          showTipoTurno
+                            ? messages.turni
+                            : messages.turni_no_tipo,
+                        )}
                         <br />
-                        {intl.formatMessage(messages.turni_en)}
+                        {intl.formatMessage(
+                          showTipoTurno
+                            ? messages.turni_en
+                            : messages.turni_no_tipo_en,
+                        )}
                       </div>
                       <PeriodsStructure
                         periods={turniDaMostrare}

--- a/src/components/Blocks/SearchFarmacia/Results.jsx
+++ b/src/components/Blocks/SearchFarmacia/Results.jsx
@@ -51,7 +51,7 @@ const messages = defineMessages({
   },
   turni_en: {
     id: 'search_farmacia_table_turni_en',
-    defaultMessage: 'Shifts periods',
+    defaultMessage: 'Shift periods and type',
   },
   ferie: {
     id: 'search_farmacia_table_ferie',
@@ -167,12 +167,9 @@ const PeriodsStructure = ({ periods }) => {
             {intl.formatMessage(messages.period_from)}
             {pd?.dal && <> {pd.dal} </>}
             {intl.formatMessage(messages.period_to) + ' '}
-            {pd?.al && (
-              <>
-                {pd.al}
-                <br />
-              </>
-            )}
+            {pd?.al && <>{pd.al}</>}
+            {pd?.tipo_turno && <> – {pd.tipo_turno}</>}
+            <br />
           </span>
         ))
       ) : (

--- a/src/components/Blocks/SearchFarmacia/Results.jsx
+++ b/src/components/Blocks/SearchFarmacia/Results.jsx
@@ -157,7 +157,7 @@ const ContactColumns = ({
   );
 };
 
-const PeriodsStructure = ({ periods }) => {
+const PeriodsStructure = ({ periods, showTipoTurno }) => {
   const intl = useIntl();
   return (
     <p>
@@ -168,7 +168,7 @@ const PeriodsStructure = ({ periods }) => {
             {pd?.dal && <> {pd.dal} </>}
             {intl.formatMessage(messages.period_to) + ' '}
             {pd?.al && <>{pd.al}</>}
-            {pd?.tipo_turno && <> – {pd.tipo_turno}</>}
+            {showTipoTurno && pd?.tipo_turno && <> – {pd.tipo_turno}</>}
             <br />
           </span>
         ))
@@ -188,6 +188,7 @@ const Results = ({
   showCap,
   showProvincia,
   showLocalitaColonna,
+  showTipoTurno,
 }) => {
   const intl = useIntl();
 
@@ -278,7 +279,10 @@ const Results = ({
                         <br />
                         {intl.formatMessage(messages.turni_en)}
                       </div>
-                      <PeriodsStructure periods={turniDaMostrare} />
+                      <PeriodsStructure
+                        periods={turniDaMostrare}
+                        showTipoTurno={showTipoTurno}
+                      />
                     </td>
                   )}
 

--- a/src/components/Blocks/SearchFarmacia/mapUtils.jsx
+++ b/src/components/Blocks/SearchFarmacia/mapUtils.jsx
@@ -18,6 +18,10 @@ const messages = defineMessages({
     id: 'search_farmacia_map_turni',
     defaultMessage: 'Periodo e tipologia di turno',
   },
+  turni_no_tipo: {
+    id: 'search_farmacia_map_turni_no_tipo',
+    defaultMessage: 'Periodo di turno',
+  },
   view_details: {
     id: 'search_farmacia_map_view_details',
     defaultMessage: 'Vedi scheda della farmacia',
@@ -69,7 +73,11 @@ const FarmaciaPopupInfo = ({
       </p>
       {periods?.length > 0 && (
         <p className="mb-1">
-          <strong>{intl.formatMessage(messages.turni)}</strong>
+          <strong>
+            {intl.formatMessage(
+              showTipoTurno ? messages.turni : messages.turni_no_tipo,
+            )}
+          </strong>
           <br />
           {periods.map((pd, i) => (
             <span key={i}>

--- a/src/components/Blocks/SearchFarmacia/mapUtils.jsx
+++ b/src/components/Blocks/SearchFarmacia/mapUtils.jsx
@@ -76,6 +76,7 @@ const FarmaciaPopupInfo = ({
               {pd?.dal && <> {pd.dal}</>}{' '}
               {intl.formatMessage(messages.period_to)}
               {pd?.al && <> {pd.al}</>}
+              {pd?.tipo_turno && <> – {pd.tipo_turno}</>}
               <br />
             </span>
           ))}

--- a/src/components/Blocks/SearchFarmacia/mapUtils.jsx
+++ b/src/components/Blocks/SearchFarmacia/mapUtils.jsx
@@ -47,6 +47,7 @@ const FarmaciaPopupInfo = ({
   showCap,
   showProvincia,
   showLocalitaColonna,
+  showTipoTurno,
   onlyActiveTurno,
   searchDate,
 }) => {
@@ -76,7 +77,7 @@ const FarmaciaPopupInfo = ({
               {pd?.dal && <> {pd.dal}</>}{' '}
               {intl.formatMessage(messages.period_to)}
               {pd?.al && <> {pd.al}</>}
-              {pd?.tipo_turno && <> – {pd.tipo_turno}</>}
+              {showTipoTurno && pd?.tipo_turno && <> – {pd.tipo_turno}</>}
               <br />
             </span>
           ))}
@@ -153,6 +154,7 @@ export const getFarmacieMarkersSignature = (items, options = {}) => {
     showCap,
     showProvincia,
     showLocalitaColonna,
+    showTipoTurno,
     onlyActiveTurno,
     searchDate,
   } = options;
@@ -185,6 +187,7 @@ export const getFarmacieMarkersSignature = (items, options = {}) => {
     showCap,
     showProvincia,
     showLocalitaColonna,
+    showTipoTurno,
     onlyActiveTurno,
     searchDate,
   ].join('::');

--- a/src/components/Blocks/SearchFarmacia/schema.js
+++ b/src/components/Blocks/SearchFarmacia/schema.js
@@ -47,6 +47,10 @@ const messages = defineMessages({
     id: 'search_farmacia_show_map',
     defaultMessage: 'Mostra la mappa con le farmacie trovate',
   },
+  show_tipo_turno: {
+    id: 'search_farmacia_show_tipo_turno',
+    defaultMessage: 'Mostra il tipo di turno nella tabella dei risultati',
+  },
   show_opendata_csv_link: {
     id: 'search_farmacia_show_opendata_csv_link',
     defaultMessage:
@@ -77,6 +81,7 @@ export function SearchFarmaciaSchema({ formData, intl }) {
           'show_provincia',
           'show_localita_colonna',
           'show_map',
+          'show_tipo_turno',
           ...(opendataCsvLinkEnabled ? ['show_opendata_csv_link'] : []),
         ],
       },
@@ -130,6 +135,11 @@ export function SearchFarmaciaSchema({ formData, intl }) {
       },
       show_map: {
         title: intl.formatMessage(messages.show_map),
+        type: 'boolean',
+        default: false,
+      },
+      show_tipo_turno: {
+        title: intl.formatMessage(messages.show_tipo_turno),
         type: 'boolean',
         default: false,
       },

--- a/src/components/View/Farmacia/FarmaciaTurni.jsx
+++ b/src/components/View/Farmacia/FarmaciaTurni.jsx
@@ -23,6 +23,7 @@ const messages = defineMessages({
 
 const FarmaciaTurni = ({ content }) => {
   const intl = useIntl();
+  const hasTipoTurno = content?.turni?.some((shift) => shift.tipo_turno);
 
   return content?.turni?.length > 0 ? (
     <RichTextSection tag_id="turni" title={intl.formatMessage(messages.turni)}>
@@ -35,9 +36,11 @@ const FarmaciaTurni = ({ content }) => {
             <th scope="col" className="text-uppercase">
               {intl.formatMessage(messages.turni_to)}
             </th>
-            <th scope="col" className="text-uppercase">
-              {intl.formatMessage(messages.turni_tipo)}
-            </th>
+            {hasTipoTurno && (
+              <th scope="col" className="text-uppercase">
+                {intl.formatMessage(messages.turni_tipo)}
+              </th>
+            )}
           </tr>
         </thead>
         <tbody>
@@ -45,7 +48,7 @@ const FarmaciaTurni = ({ content }) => {
             <tr key={index}>
               <td>{shift.dal}</td>
               <td>{shift.al}</td>
-              <td>{shift.tipo_turno}</td>
+              {hasTipoTurno && <td>{shift.tipo_turno}</td>}
             </tr>
           ))}
         </tbody>

--- a/src/components/View/Farmacia/FarmaciaTurni.jsx
+++ b/src/components/View/Farmacia/FarmaciaTurni.jsx
@@ -15,6 +15,10 @@ const messages = defineMessages({
     id: 'farmacia_turni_to',
     defaultMessage: 'Al',
   },
+  turni_tipo: {
+    id: 'farmacia_turni_tipo',
+    defaultMessage: 'Tipo turno',
+  },
 });
 
 const FarmaciaTurni = ({ content }) => {
@@ -31,6 +35,9 @@ const FarmaciaTurni = ({ content }) => {
             <th scope="col" className="text-uppercase">
               {intl.formatMessage(messages.turni_to)}
             </th>
+            <th scope="col" className="text-uppercase">
+              {intl.formatMessage(messages.turni_tipo)}
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -38,6 +45,7 @@ const FarmaciaTurni = ({ content }) => {
             <tr key={index}>
               <td>{shift.dal}</td>
               <td>{shift.al}</td>
+              <td>{shift.tipo_turno}</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- Aggiunge la visualizzazione del campo `tipo_turno` accanto a `dal`/`al` nella pagina farmacia (`FarmaciaTurni.jsx`), nella tabella risultati e nel popup mappa del blocco Ricerca Farmacie (`Results.jsx`, `mapUtils.jsx`).
- Corregge la label inglese dell'intestazione turni nel blocco Ricerca Farmacie, che non menzionava la tipologia di turno ("Shifts periods" → "Shift periods and type").

Il campo `tipo_turno` arriva dal backend `auslfe.farmacie` (vedi MR collegata su iosanita-farmacie).

## Test plan
- [x] `pnpm test` non applicabile: nessuna suite esistente su questi componenti
- [ ] Verifica manuale su pagina farmacia con turni con `tipo_turno` popolato
- [ ] Verifica manuale su blocco Ricerca Farmacie (tabella risultati + popup mappa)