### PR TITLE
Bug76122 - FIX: grid video block url updating

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,14 @@
 - ...
  -->
 
+## Versione X.X.X (dd/mm/yyyy)
+
+### Fix
+
+- - All'interno del blocco video dentro un blocco Griglia, è stato risolto il problema per cui non era possibile digitare o incollare l'url se il blocco video non era già selezionato.
+
+
+
 ## Versione 2.37.0 (12/08/2026)
 
 ### Novità

--- a/src/customizations/volto/components/manage/Blocks/Video/Edit.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/Edit.jsx
@@ -106,11 +106,12 @@ class Edit extends Component {
    * @returns {boolean}
    * @memberof Edit
    */
-  shouldComponentUpdate(nextProps) {
+  shouldComponentUpdate(nextProps, nextState) {
     return (
       this.props.selected ||
       nextProps.selected ||
-      !isEqual(this.props.data, nextProps.data)
+      !isEqual(this.props.data, nextProps.data) ||
+      !isEqual(this.state, nextState)
     );
   }
 


### PR DESCRIPTION
https://redturtle.tpondemand.com/restui/board.aspx?#page=bug/76122

Inside a Grid block, typing in the video block url input was showing the cursor but nothing typed appeared if the focus wasn't on the video block itself.
